### PR TITLE
Add .clang-format for code style, clean up global variables, add a 'cd' command, and modify the readline prompt to show the username and current directory.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,280 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never 
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLine
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ build/
 test
 .vscode/
 .cache/
-
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cash
     LANGUAGES C 
 )
 
-set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -O0")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
@@ -14,6 +14,7 @@ add_executable(cash
     src/parser/lexer.c
     src/parser/parser.c
     src/vm.c
+    src/util.c
     src/string.c
     src/ast.c
     src/repl.c

--- a/include/cash/colors.h
+++ b/include/cash/colors.h
@@ -1,15 +1,18 @@
 #ifndef CASH_COLORS_H
 #define CASH_COLORS_H
 
-#define RED "\033[0;31m"
-#define GREEN "\033[0;32m"
-#define YELLOW "\033[0;33m"
-#define BLUE "\033[0;34m"
-#define MAGENTA "\033[0;35m"
-#define CYAN "\033[0;36m"
-#define WHITE "\033[0;37m"
+#define RED "\033[31m"
+#define GREEN "\033[32m"
+#define YELLOW "\033[33m"
+#define BLUE "\033[34m"
+#define MAGENTA "\033[35m"
+#define CYAN "\033[36m"
+#define WHITE "\033[37m"
 #define RESET "\033[0m"
 #define BOLD "\033[1m"
 #define UNDERLINE "\033[4m"
+
+#define COLOR_LEN 7
+#define COLOR_ATTR_LEN 4
 
 #endif  // CASH_COLORS_H

--- a/include/cash/error.h
+++ b/include/cash/error.h
@@ -20,4 +20,9 @@
             exit(status);                                                    \
     } while (0)
 
+#define cash_warning(fmt, ...)                                                 \
+    do {                                                                       \
+        fprintf(stderr, YELLOW "cash: " fmt RESET __VA_OPT__(, ) __VA_ARGS__); \
+    } while (0)
+
 #endif

--- a/include/cash/parser/lexer.h
+++ b/include/cash/parser/lexer.h
@@ -3,6 +3,7 @@
 
 #include <cash/ast.h>
 #include <cash/parser/token.h>
+#include <stdbool.h>
 
 struct Lexer {
     bool repl_mode;

--- a/include/cash/repl.h
+++ b/include/cash/repl.h
@@ -1,6 +1,17 @@
 #ifndef REPL_H
 #define REPL_H
 
-void run_repl(void);
+#include <cash/parser/parser.h>
+#include <cash/vm.h>
+
+struct Repl {
+    struct Parser parser;
+    struct VM vm;
+    char* line;
+};
+
+struct Repl make_repl(void);
+void run_repl(struct Repl* repl);
+void free_repl(struct Repl* repl);
 
 #endif

--- a/include/cash/string.h
+++ b/include/cash/string.h
@@ -42,7 +42,8 @@ void add_string_component(struct ShellString* str,
                           enum StringComponentType type, const char* value,
                           int length);
 void free_string_component(struct StringComponent* component);
-void free_string(struct ShellString* str);
+void free_shell_string(struct ShellString* str);
+void free_string(const struct String* string);
 
 struct String expand_component(const struct StringComponent* component);
 struct String to_string(const struct ShellString* str);

--- a/include/cash/util.h
+++ b/include/cash/util.h
@@ -1,0 +1,9 @@
+#ifndef CASH_UTIL_H_
+#define CASH_UTIL_H_
+
+#include <pwd.h>
+
+const struct passwd* get_pw(void);
+char* make_new_prompt(const char* username);
+
+#endif  // CASH_UTIL_H_

--- a/include/cash/vm.h
+++ b/include/cash/vm.h
@@ -2,8 +2,18 @@
 #define CASH_VM_H_
 
 #include <cash/ast.h>
+#include <pwd.h>
 
-void run_program(struct Program* program);
-void run_command(struct Command* command);
+struct VM {
+    char* current_prompt;
+    uid_t uid;
+    struct passwd* userpw;
+};
+
+struct VM make_vm(void);
+void free_vm(const struct VM* vm);
+
+void run_program(struct VM* vm, const struct Program* program);
+void run_command(struct VM* vm, struct Command* command);
 
 #endif

--- a/src/ast.c
+++ b/src/ast.c
@@ -17,12 +17,12 @@ void add_argument(struct ArgumentList *list, struct ShellString arg) {
 
 void free_arg_list(struct ArgumentList *list) {
     for (int i = 0; i < list->argument_count; ++i)
-        free_string(&list->arguments[i]);
+        free_shell_string(&list->arguments[i]);
     free(list->arguments);
 }
 
 void free_stmt(struct Stmt *stmt) {
-    free_string(&stmt->command.command_name);
+    free_shell_string(&stmt->command.command_name);
     free_arg_list(&stmt->command.arguments);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,8 +1,5 @@
 #include <cash/ast.h>
 #include <cash/error.h>
-#include <cash/parser/lexer.h>
-#include <cash/parser/token.h>
-// #include <cash/parser/parser_driver.h>
 #include <cash/repl.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -12,51 +9,33 @@
 #include "cash/parser/parser.h"
 #include "cash/vm.h"
 
-// #include "parse.tab.h"
-// #include "lexer.yy.h"
-
 bool REPL_MODE = false;
 
 static char* read_file(const char* path);
 static void run_file(const char* path);
 
-// int cash_lex(YYSTYPE* yylval, YYLTYPE* yylloc, yyscan_t yyscanner,
-//              struct Driver* driver);
-// int yyparse(yyscan_t yyscanner, struct Driver* program);
-// int yylex_destroy(yyscan_t scanner);
-
-int main(int argc, char* argv[]) {
+int main(const int argc, char* argv[]) {
     if (argc == 1) {
         REPL_MODE = true;
-        run_repl();
+        struct Repl repl = make_repl();
+        run_repl(&repl);
     } else {
         run_file(argv[1]);
     }
-    // yyscan_t scanner;
-    // yylex_init(&scanner);
-
-    // struct Driver driver;
-    // yyparse(&scanner, &driver);
-    // print_program(&driver.program);
-    // free_program(&driver.program);
-
-    // yylex_destroy(&scanner);
 }
-
-// int main(int argc, char* argv[]);
 
 static char* read_file(const char* path) {
     FILE* file = fopen(path, "r");
     if (!file) {
         cash_error(EXIT_FAILURE, "could not read file " BOLD WHITE "%s", path);
     }
-    int seek_stat = fseek(file, 0L, SEEK_END);
+    const int seek_stat = fseek(file, 0L, SEEK_END);
     if (seek_stat != 0) {
         cash_perror(seek_stat, "fseek",
                     "could not seek end of file " BOLD WHITE "%s", path);
     }
 
-    long size = ftell(file);
+    const long size = ftell(file);
     if (size == -1L) {
         cash_perror(size, "ftell",
                     "could not determine length of file " BOLD WHITE "%s",
@@ -65,7 +44,8 @@ static char* read_file(const char* path) {
     rewind(file);
 
     char* buffer = malloc((size_t)size + 1);
-    size_t read_size = fread((void*)buffer, sizeof(char), (size_t)size, file);
+    const size_t read_size =
+        fread((void*)buffer, sizeof(char), (size_t)size, file);
 
     if (read_size != (size_t)size) {
         if (feof(file))
@@ -87,13 +67,14 @@ static char* read_file(const char* path) {
 static void run_file(const char* path) {
     char* contents = read_file(path);
 
+    struct VM vm = make_vm();
     struct Parser parser = parser_new(contents, false);
     parse_program(&parser);
     struct Program prog = parser.program;
 
     print_program(&prog);
 
-    run_program(&prog);
+    run_program(&vm, &prog);
 
     free_program(&prog);
     free_parser(&parser);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,18 +1,18 @@
-#include <cash/ast.h>
 #include <cash/parser/lexer.h>
 #include <cash/parser/parser.h>
 #include <cash/parser/token.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include "cash/error.h"
 
 extern bool REPL_MODE;
 
-static bool is_at_end(struct Parser* parser);
-static struct Token peek(struct Parser* parser);
-static enum TokenType peek_tt(struct Parser* parser);
-static struct Token peek_next(struct Parser* parser);
+static bool is_at_end(const struct Parser* parser);
+static struct Token peek(const struct Parser* parser);
+static enum TokenType peek_tt(const struct Parser* parser);
+static struct Token peek_next(const struct Parser* parser);
 static struct Token advance(struct Parser* parser);
 static bool match(enum TokenType type, struct Parser* parser);
 static struct Token consume(enum TokenType type, struct Parser* parser);
@@ -44,7 +44,7 @@ void free_parser(struct Parser* parser) {
 bool parse_program(struct Parser* parser) {
     parser->current_token = lexer_next_token(&parser->lexer);
     parser->next_token = lexer_next_token(&parser->lexer);
-    while (peek(parser).type != TOKEN_EOF) {
+    while (peek_tt(parser) != TOKEN_EOF) {
         if (parser->error) {
             return false;
         }
@@ -68,13 +68,13 @@ static bool skip_line_terminator(struct Parser* parser) {
 }
 
 static bool parse_statement(struct Parser* parser, struct Stmt* stmt) {
-    struct ShellString command_name = consume(TOKEN_WORD, parser).value.word;
+    const struct ShellString command_name = consume(TOKEN_WORD, parser).value.word;
     struct ArgumentList arg_list = make_arg_list();
 
     while (!is_at_end(parser)) {
         if (parser->error)
             return false;
-        struct Token argument = consume(TOKEN_WORD, parser);
+        const struct Token argument = consume(TOKEN_WORD, parser);
         add_argument(&arg_list, argument.value.word);
 
         if (peek_tt(parser) == TOKEN_SEMICOLON ||
@@ -92,19 +92,19 @@ static bool parse_statement(struct Parser* parser, struct Stmt* stmt) {
     return true;
 }
 
-static bool is_at_end(struct Parser* parser) {
+static bool is_at_end(const struct Parser* parser) {
     return parser->current_token.type == TOKEN_EOF;
 }
 
-static struct Token peek(struct Parser* parser) {
+static struct Token peek(const struct Parser* parser) {
     return parser->current_token;
 }
 
-static enum TokenType peek_tt(struct Parser* parser) {
+static enum TokenType peek_tt(const struct Parser* parser) {
     return parser->current_token.type;
 }
 
-static struct Token peek_next(struct Parser* parser) {
+static struct Token peek_next(const struct Parser* parser) {
     return parser->next_token;
 }
 

--- a/src/parser/token.c
+++ b/src/parser/token.c
@@ -31,6 +31,7 @@ const char* token_type_to_string(enum TokenType type) {
         TO_STRING_TT(TOKEN_ERROR, "<ERROR>");
         TO_STRING_TT(TOKEN_EOF, "<EOF>");
     }
+    return "";
 }
 
 const char* dump_token_type(enum TokenType type) {

--- a/src/repl.c
+++ b/src/repl.c
@@ -1,53 +1,62 @@
 #include <cash/ast.h>
-#include <cash/error.h>
 #include <cash/parser/lexer.h>
 #include <cash/parser/parser.h>
-#include <cash/parser/token.h>
 #include <cash/repl.h>
+#include <cash/util.h>
 #include <cash/vm.h>
 #include <readline/history.h>
 #include <readline/readline.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 extern bool REPL_MODE;
-extern char **environ;
+extern char** environ;
 
-void run_repl(void) {
-    char *line = readline("$> ");
-    struct Parser parser = parser_new(line, true);
-    if (!line) {
-        printf("Exit.\n");
-        goto exit_repl;
-    }
+static bool get_line(struct Repl* repl);
 
+struct Repl make_repl() {
+    return (struct Repl){
+        .parser = parser_new("", true), .vm = make_vm(), .line = NULL};
+}
+
+void run_repl(struct Repl* repl) {
     while (1) {
-        add_history(line);
-        lexer_lex_full(&parser.lexer);
-        bool success = parse_program(&parser);
-        struct Program program = parser.program;
+        if (!get_line(repl)) {
+            break;
+        }
+
+        reset_parser(repl->line, &repl->parser);
+        lexer_lex_full(&repl->parser.lexer);
+
+        const bool success = parse_program(&repl->parser);
+
+        struct Program program = repl->parser.program;
         if (success) {
             print_program(&program);
             printf("\n");
 
-            run_program(&program);
-        } else {
-            program = make_program();
+            run_program(&repl->vm, &program);
+            free_program(&program);
         }
-
-        free_program(&program);
-        free(line);
-
-        line = readline("$> ");
-        if (!line) {
-            printf("Exit.\n");
-            goto exit_repl;
-        }
-        reset_parser(line, &parser);
     }
 
-exit_repl:
-    free_parser(&parser);
+    free_repl(repl);
+}
+
+void free_repl(struct Repl* repl) {
+    free_parser(&repl->parser);
     clear_history();
-    free(line);
+    free(repl->line);
+    free_vm(&repl->vm);
+}
+
+static bool get_line(struct Repl* repl) {
+    free(repl->line);
+    repl->line = readline(repl->vm.current_prompt);
+    if (repl->line) {
+        add_history(repl->line);
+        return true;
+    }
+    return false;
 }

--- a/src/string.c
+++ b/src/string.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "cash/error.h"
+#include <stdbool.h>
 
 extern bool REPL_MODE;
 
@@ -51,6 +51,7 @@ void add_string_component(struct ShellString *str,
             component.literal = val;
             break;
         default:
+            break;
     }
 
     add_component(str, component);
@@ -75,10 +76,14 @@ void free_string_component(struct StringComponent *component) {
     }
 }
 
-void free_string(struct ShellString *str) {
+void free_shell_string(struct ShellString *str) {
     for (int i = 0; i < str->component_count; ++i)
         free_string_component(&str->components[i]);
     free(str->components);
+}
+
+void free_string(const struct String* string) {
+    free(string->string);
 }
 
 static char *grow_string(char *str, int new_size) {
@@ -141,11 +146,11 @@ struct String to_string(const struct ShellString *string) {
     int total_size = 0;
 
     for (int i = 0; i < string->component_count; ++i) {
-        struct String expanded = expand_component(&string->components[i]);
+        const struct String expanded = expand_component(&string->components[i]);
         // printf("expanded (%d): %.*s\n", expanded.length, expanded.length,
         //        expanded.string);
-        int is_last_comp = i + 1 == string->component_count;
-        int new_alloc_size = total_size + expanded.length + is_last_comp;
+        const int is_last_comp = i + 1 == string->component_count;
+        const int new_alloc_size = total_size + expanded.length + is_last_comp;
         // printf("new alloc size: %d\n", new_alloc_size);
         str = grow_string(str, new_alloc_size);
         // printf("copying at position %d in (%d) \"%.*s\"\n", total_size,

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,34 @@
+#include <cash/colors.h>
+#include <cash/error.h>
+#include <cash/util.h>
+#include <pwd.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+extern char *const *environ;
+extern bool REPL_MODE;
+
+const struct passwd *get_pw(void) {
+    const struct passwd *pw = getpwuid(getuid());
+    if (pw == NULL) {
+        cash_perror(EXIT_FAILURE, "getpwuid",
+                    "could not get user entry (fatal error)\n%s", "");
+        exit(EXIT_FAILURE);
+    }
+    return pw;
+}
+
+char *make_new_prompt(const char *username) {
+    char *cwd = getcwd(NULL, 0);
+
+    const size_t size_needed = strlen(username) + strlen(cwd) +
+                               (COLOR_ATTR_LEN * 4) + (COLOR_LEN * 2) + 3;
+    char *buf = malloc(size_needed * sizeof(char));
+    sprintf(buf, BOLD GREEN "%s" RESET ":" BOLD BLUE "%s" RESET "$ ", username,
+            cwd);
+
+    free(cwd);
+    return buf;
+}


### PR DESCRIPTION
### Code Formatting and Build Configuration:
* Added a `.clang-format` file to enforce consistent C++ code formatting based on the Google style guide with customizations.
* Downgraded the C standard from C23 to C17 in the `CMakeLists.txt` file.

### New Features and Enhancements:
* Introduced a `cash_warning` macro in `include/cash/error.h` for printing warnings with a yellow color prefix.
* Added a `struct Repl` and associated functions (`make_repl`, `run_repl`, `free_repl`) to encapsulate REPL state into structs instead of global variables [[1]](diffhunk://#diff-6288e27d110825905c98bcecf2e344c07d4ef1903db211a4676f8b3ca226f39dL4-R15) [[2]](diffhunk://#diff-7b70f5851a8f769127d15dbee814126494abfb82a9d51cf4973b79a936b7876aL2-R61)
* Defined a `struct VM` with user and prompt information, along with functions (`make_vm`, `free_vm`) to manage VM state and removed global variables.

### Refactoring and Code Simplification:
* Refactored the REPL implementation to use the new `struct Repl` and removed redundant code.
* Updated function signatures and internal logic to use `const` where applicable for better type safety (e.g., `is_at_end`, `peek`, `peek_tt` in `parser.c`). [[1]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL1-R15) [[2]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL95-R107)

### Utility and Helper Functions:
* The shell now shows the username and current directory in the prompt.
* Added `get_pw` and `make_new_prompt` utility functions in a new `include/cash/util.h` file to handle prompt and other system related functions.
* Renamed `free_string` to `free_shell_string` and created a new `free_string` to free `struct String`. [[1]](diffhunk://#diff-765b269984e98771482c421eead6d01c72687bb29e71aad6e9fbff71437fa618L45-R46) [[2]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL20-R25)

### Minor Updates:
* Adjusted ANSI color code definitions for simplicity and added constants for color string lengths in `include/cash/colors.h`.
* Added `src/util.c` to the build system in `CMakeLists.txt`.