### PR TITLE
Redirections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,33 @@
 ## CaSH: A toy Linux shell
 
-Currently, it supports:
+Currently, it can:
 
-- Parsing of basic commands
-- Can recognize basic escape sequences and supports double-quoted, single quoted and unquoted strings
-- Can execute executables given the full path, or any executable in any directory present in `$PATH`
-- Supports arrow key navigation and other functionalities provided by `readline`
-- REPL mode and file execution mode
+- Parse basic commands
+- Recognize basic escape sequences and supports double-quoted, single quoted and unquoted strings
+- Execute executables given the full path, or any executable in any directory present in `$PATH`
+- Support arrow key navigation and other functionalities provided by `readline` (including history of current session)
+- Execute in REPL or file execution mode
+- Handle `&&` and `||` lists and the `!` operator
+- Handle execution in a subshell (using `()`)
+- Expand environment variables (using `$` only, `${}` doesn't work yet)
+- Handle shell builtings:
+    - `cd` to change directories (supports `-` to switch to previous directory)
+    - `exit` to exit the shell
+- Set `$OLDPWD` and `$PWD` environment variables, whenever directory changes
+- Set `$?` environment variable to the exit status of the last command executed
+- Handle piped lists of commands (using `|`)
+- Handle redirections (`i` and `j` are file descriptors, `file` is a path):
+    - `[i]> file`
+    - `[i]>> file`
+    - `[i]&> file`
+    - `[i]&>> file`
+    - `[i]< file`
+    - `[i]<> file`
+    - `[i]>&[j]` 
+
+## Major Problems
+- Does not handle signals (like `SIGINT`, `SIGTERM`, etc.) yet
+- Has very, very, very messy error handling. (mostly because of my inexperience in doing so in C).
 
 ## Usage
 

--- a/include/cash/ast.h
+++ b/include/cash/ast.h
@@ -3,6 +3,23 @@
 
 #include <cash/string.h>
 
+enum RedirectionType {
+    REDIRECT_IN,
+    REDIRECT_OUT,
+    REDIRECT_INOUT,
+    REDIRECT_OUTERR,
+    REDIRECT_APPEND_OUT,
+    REDIRECT_APPEND_OUTERR,
+    REDIRECT_OUT_DUPLICATE
+};
+
+struct Redirection {
+    enum RedirectionType type;
+    int left;
+    int right;
+    struct ShellString file_name;
+};
+
 struct ArgumentList {
     struct ShellString* arguments;
     int argument_count;
@@ -15,6 +32,10 @@ void free_arg_list(const struct ArgumentList* list);
 struct Command {
     struct ShellString command_name;
     struct ArgumentList arguments;
+
+    struct Redirection* redirections;
+    int redirection_count;
+    int redirection_capacity;
 };
 
 enum ExprType {
@@ -58,5 +79,6 @@ void print_program(const struct Program* program, int indent);
 void print_statement(const struct Stmt* stmt, int indent);
 void print_expr(const struct Expr* expr, int indent);
 void print_command(const struct Command* command);
+void print_redirection(const struct Redirection* redirection);
 
 #endif  // CASH_AST_H

--- a/include/cash/parser/lexer.h
+++ b/include/cash/parser/lexer.h
@@ -11,6 +11,7 @@ struct Lexer {
     const char* input;
     int token_start;
     int position;
+    int backtrack_position;
 
     int first_line;
     int first_column;
@@ -24,6 +25,7 @@ struct Lexer {
 
     bool continue_string;
     bool substitution_in_quotes;
+    bool string_was_number;
     struct ShellString current_string;
 };
 

--- a/include/cash/parser/token.h
+++ b/include/cash/parser/token.h
@@ -20,9 +20,7 @@ enum TokenType {
     TOKEN_NOT,
 
     TOKEN_PIPE,
-    TOKEN_REDIRECT_IN,
-    TOKEN_REDIRECT_OUT,
-    TOKEN_REDIRECT_APPEND,
+    TOKEN_REDIRECT,
 
     TOKEN_ERROR,
     TOKEN_EOF,
@@ -35,12 +33,17 @@ struct Token {
     int last_line;
     int last_column;
 
-    const char* lexeme;
     int lexeme_length;
+    const char* lexeme;
 
     union {
         long number;
         struct ShellString word;
+        struct {
+            enum RedirectionType type;
+            int left;
+            int right;
+        } redirection;
     } value;
 };
 

--- a/include/cash/vm.h
+++ b/include/cash/vm.h
@@ -19,6 +19,6 @@ struct Vm make_vm(void);
 void free_vm(const struct Vm* vm);
 
 int run_program(struct Vm* vm, const struct Program* program);
-int run_command(struct Vm* vm, struct Command* command);
+int run_command(struct Vm* vm, struct Command* command, int in, int out);
 
 #endif  // CASH_VM_H

--- a/src/ast.c
+++ b/src/ast.c
@@ -169,8 +169,51 @@ void print_command(const struct Command *command) {
     printf("%s" RESET, command->arguments.argument_count ? " " : "");
     for (int i = 0; i < command->arguments.argument_count; ++i) {
         print_string(&command->arguments.arguments[i]);
-        if (i != command->arguments.argument_count - 1)
-            printf(" ");
+        printf(" ");
+    }
+
+    for (int i = 0; i < command->redirection_count; ++i) {
+        print_redirection(&command->redirections[i]);
+        printf(" ");
     }
     printf(")");
+}
+
+void print_redirection(const struct Redirection *redirection) {
+    printf("( ");
+    if (redirection->left != -1) {
+        printf(CYAN "%d" RESET, redirection->left);
+    }
+
+    switch (redirection->type) {
+        case REDIRECT_IN:
+            printf(YELLOW "<" RESET);
+            break;
+        case REDIRECT_OUT:
+            printf(YELLOW ">" RESET);
+            break;
+        case REDIRECT_OUT_DUPLICATE:
+            printf(YELLOW ">&" RESET);
+            break;
+        case REDIRECT_OUTERR:
+            printf(YELLOW "&>" RESET);
+            break;
+        case REDIRECT_APPEND_OUT:
+            printf(YELLOW ">>" RESET);
+            break;
+        case REDIRECT_APPEND_OUTERR:
+            printf(YELLOW "&>>" RESET);
+            break;
+        case REDIRECT_INOUT:
+            printf(YELLOW "<>" RESET);
+            break;
+    }
+
+    if (redirection->right != -1) {
+        printf(CYAN "%d" RESET, redirection->right);
+    } else {
+        printf(" ");
+        print_string(&redirection->file_name);
+    }
+    printf(" )");
 }

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -3,6 +3,7 @@
 #include <cash/parser/lexer.h>
 #include <cash/parser/token.h>
 #include <ctype.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -13,11 +14,14 @@
 extern bool repl_mode;
 
 static char peek(const struct Lexer* lexer);
-// static char peek_next(struct Lexer* lexer);
+static char peek_next(const struct Lexer* lexer);
 static char advance(struct Lexer* lexer);
 static bool match(struct Lexer* lexer, char c);
 static bool is_at_end(const struct Lexer* lexer);
+static void backtrack(struct Lexer* lexer);
 
+static struct Token make_redirection_token(enum RedirectionType type, int left,
+                                           int right, struct Lexer* lexer);
 static struct Token make_token(enum TokenType type, struct Lexer* lexer);
 static struct Token make_error(struct Lexer* lexer);
 static struct Token make_eof(const struct Lexer* lexer);
@@ -25,6 +29,7 @@ static struct Token make_eof(const struct Lexer* lexer);
 static void skip_ws(struct Lexer* lexer);
 static struct Token consume_lines(struct Lexer* lexer);
 
+static bool try_consume_number(struct Lexer* lexer, bool eof_ok, int* number);
 static struct Token consume_string(struct Lexer* lexer);
 static void consume_sq_string(struct Lexer* lexer);
 static void consume_dq_string(struct Lexer* lexer);
@@ -40,8 +45,8 @@ static void lexer_reset_queue(struct Lexer* lexer);
 static const bool kPunctuation[128] = {
     ['>'] = true,  ['|'] = true,  ['<'] = true,  ['('] = true, [')'] = true,
     ['\''] = true, ['"'] = true,  [';'] = true,  ['&'] = true, ['`'] = true,
-    ['$'] = true,  ['\t'] = true, ['\n'] = true, [' '] = true};
-// ">|<()'\";&`$\t\n"
+    ['$'] = true,  ['\t'] = true, ['\n'] = true, [' '] = true, ['\r'] = true};
+// ">|<()'\";&`$\t\n\r"
 
 struct Lexer* lexer_new(const char* input, bool repl_mode) {
     struct Lexer* lexer = malloc(sizeof(struct Lexer));
@@ -51,6 +56,7 @@ struct Lexer* lexer_new(const char* input, bool repl_mode) {
         .input = input,
         .token_start = 0,
         .position = 0,
+        .backtrack_position = 0,
 
         .first_line = 1,
         .first_column = 1,
@@ -71,12 +77,14 @@ struct Lexer* lexer_new(const char* input, bool repl_mode) {
 void reset_lexer(const char* input, struct Lexer* lexer) {
     lexer->error = false;
     lexer->input = input;
-    lexer->token_start = lexer->position = 0;
+    lexer->token_start = 0;
+    lexer->position = 0;
     lexer->first_column = lexer->first_line = lexer->last_column =
         lexer->last_line = 1;
     lexer_reset_queue(lexer);
     lexer->continue_string = false;
     lexer->substitution_in_quotes = false;
+    lexer->backtrack_position = 0;
 }
 
 void free_lexer(const struct Lexer* lexer) {
@@ -96,6 +104,7 @@ struct Token lexer_next_token(struct Lexer* lexer) {
 void lexer_lex_full(struct Lexer* lexer) {
     while (true) {
         const struct Token token = lexer_lex(lexer);
+        dump_token(&token);
         lexer_push_token(lexer, token);
         if (token.type == TOKEN_EOF)
             break;
@@ -118,6 +127,38 @@ static struct Token lexer_lex(struct Lexer* lexer) {
     if (is_at_end(lexer))
         return make_eof(lexer);
 
+    lexer->backtrack_position = lexer->position;
+    int left = -1, right = -1;
+    enum RedirectionType redir_type = REDIRECT_IN;
+
+    if (try_consume_number(lexer, false, &left)) {
+        if (peek(lexer) == '>' && peek_next(lexer) == '>') {
+            advance(lexer);
+            advance(lexer);
+            return make_redirection_token(REDIRECT_APPEND_OUT, left, -1, lexer);
+        }
+
+        if (peek(lexer) == '<') {
+            advance(lexer);
+
+            if (peek(lexer) == '>') {
+                advance(lexer);
+                return make_redirection_token(REDIRECT_INOUT, left, -1, lexer);
+            }
+            return make_redirection_token(REDIRECT_IN, left, -1, lexer);
+        }
+
+        if (peek(lexer) != '>') {
+            struct ShellString string = make_string();
+            add_string_literal(&string, STRING_COMPONENT_LITERAL,
+                               &lexer->input[lexer->backtrack_position],
+                               lexer->position - lexer->backtrack_position, 0);
+            struct Token token = make_token(TOKEN_WORD, lexer);
+            token.value.word = string;
+            return token;
+        }
+    }
+
     switch (peek(lexer)) {
         CHAR('(', TOKEN_LPAREN);
         CHAR(')', TOKEN_RPAREN);
@@ -125,8 +166,38 @@ static struct Token lexer_lex(struct Lexer* lexer) {
         CHAR('!', TOKEN_NOT);
         case '&':
             advance(lexer);
+            if (peek(lexer) == '>') {
+                advance(lexer);
+                if (peek(lexer) == '>') {
+                    advance(lexer);
+                    return make_redirection_token(REDIRECT_APPEND_OUTERR, -1,
+                                                  -1, lexer);
+                }
+                return make_redirection_token(REDIRECT_OUTERR, -1, -1, lexer);
+            }
             return match(lexer, '&') ? make_token(TOKEN_AND, lexer)
                                      : make_token(TOKEN_AMP, lexer);
+        case '>': {
+            advance(lexer);
+            if (peek(lexer) == '>') {
+                advance(lexer);
+                return make_redirection_token(REDIRECT_APPEND_OUT, left, -1,
+                                              lexer);
+            }
+            if (peek(lexer) == '&') {
+                advance(lexer);
+                redir_type = REDIRECT_OUT_DUPLICATE;
+            } else
+                redir_type = REDIRECT_OUT;
+
+            try_consume_number(lexer, true, &right);
+            return make_redirection_token(redir_type, left, right, lexer);
+        }
+        case '<':
+            advance(lexer);
+            return match(lexer, '>')
+                       ? make_redirection_token(REDIRECT_INOUT, left, -1, lexer)
+                       : make_redirection_token(REDIRECT_IN, -1, -1, lexer);
         case '|':
             advance(lexer);
             return match(lexer, '|') ? make_token(TOKEN_OR, lexer)
@@ -143,11 +214,11 @@ static char peek(const struct Lexer* lexer) {
     return lexer->input[lexer->position];
 }
 
-// static char peek_next(struct Lexer* lexer) {
-//     if (is_at_end(lexer))
-//         return '\0';
-//     return lexer->input[lexer->position + 1];
-// }
+static char peek_next(const struct Lexer* lexer) {
+    if (is_at_end(lexer))
+        return '\0';
+    return lexer->input[lexer->position + 1];
+}
 
 static char advance(struct Lexer* lexer) {
     if (is_at_end(lexer))
@@ -159,11 +230,49 @@ static bool is_at_end(const struct Lexer* lexer) {
     return peek(lexer) == '\0';
 }
 
+static void backtrack(struct Lexer* lexer) {
+    lexer->last_column -= (lexer->position - lexer->backtrack_position);
+    lexer->position = lexer->backtrack_position;
+}
+
 static void skip_ws(struct Lexer* lexer) {
     while (peek(lexer) != '\n' && isspace(peek(lexer))) {
         lexer->last_column++;
         advance(lexer);
     }
+}
+
+static bool try_consume_number(struct Lexer* lexer, bool eof_ok, int* number) {
+    if (!isdigit(peek(lexer))) {
+        return false;
+    }
+
+    char* endptr;
+    const char* begin = &lexer->input[lexer->position];
+    const long n = strtol(begin, &endptr, 10);
+    if (endptr == begin) {
+        return false;
+    }
+
+    if (errno == ERANGE || n > INT_MAX) {
+        lexer->position = lexer->backtrack_position;
+        return false;
+    }
+
+    if (*endptr == '\0' && !eof_ok) {
+        lexer->position = lexer->backtrack_position;
+        return false;
+    }
+
+    if (!kPunctuation[(int)*endptr]) {
+        lexer->position = lexer->backtrack_position;
+        return false;
+    }
+
+    *number = (int)n;
+    lexer->position += (int)(endptr - begin);
+    lexer->last_column += (int)(endptr - begin);
+    return true;
 }
 
 static struct Token consume_lines(struct Lexer* lexer) {
@@ -186,6 +295,15 @@ static bool match(struct Lexer* lexer, char c) {
         return true;
     }
     return false;
+}
+
+static struct Token make_redirection_token(enum RedirectionType type, int left,
+                                           int right, struct Lexer* lexer) {
+    struct Token tok = make_token(TOKEN_REDIRECT, lexer);
+    tok.value.redirection.type = type;
+    tok.value.redirection.left = left;
+    tok.value.redirection.right = right;
+    return tok;
 }
 
 static struct Token make_token(enum TokenType type, struct Lexer* lexer) {
@@ -233,6 +351,7 @@ static struct Token make_eof(const struct Lexer* lexer) {
 static struct Token consume_string(struct Lexer* lexer) {
     lexer->continue_string = true;
     lexer->current_string = make_string();
+    lexer->string_was_number = true;
     while (true) {
         if (lexer->error)
             return make_error(lexer);
@@ -244,14 +363,17 @@ static struct Token consume_string(struct Lexer* lexer) {
         }
 
         const char c = peek(lexer);
-        if (c == '\'')
+        if (c == '\'') {
+            lexer->string_was_number = false;
             consume_sq_string(lexer);
-        else if (c == '"') {
+        } else if (c == '"') {
+            lexer->string_was_number = false;
             advance(lexer);
             consume_dq_string(lexer);
-        } else if (c == '$')
+        } else if (c == '$') {
             consume_substitution(lexer);
-        else if (!is_at_end(lexer) && !kPunctuation[(int)c])
+            lexer->string_was_number = false;
+        } else if (!is_at_end(lexer) && !kPunctuation[(int)c])
             consume_unquoted_string(lexer);
         else
             break;
@@ -268,6 +390,8 @@ static void consume_unquoted_string(struct Lexer* lexer) {
     const int string_start = lexer->position;
     int escapes = 0;
     while (!is_at_end(lexer) && !kPunctuation[(int)(c = peek(lexer))]) {
+        if (!isdigit(c))
+            lexer->string_was_number = false;
         if (c == '\\') {
             escapes++;
             advance(lexer);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -214,7 +214,6 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
     bool break_out = false;
 
     while (!is_at_end(parser) && !break_out) {
-        printf("Whooo\n");
         if (parser->error)
             return false;
 
@@ -246,6 +245,9 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
                 handle_redirection(parser, &command, advance(parser));
                 break;
 
+            case TOKEN_ERROR:
+                parser->error = true;
+                return false;
             default:
                 CASH_ERROR(EXIT_FAILURE, "IMPOSSIBLE");
                 exit(EXIT_FAILURE);

--- a/src/parser/token.c
+++ b/src/parser/token.c
@@ -27,9 +27,7 @@ const char* token_type_to_string(enum TokenType type) {
         TO_STRING_TT(TOKEN_LPAREN, "(");
         TO_STRING_TT(TOKEN_RPAREN, ")");
         TO_STRING_TT(TOKEN_PIPE, "|");
-        TO_STRING_TT(TOKEN_REDIRECT_IN, "<");
-        TO_STRING_TT(TOKEN_REDIRECT_OUT, ">");
-        TO_STRING_TT(TOKEN_REDIRECT_APPEND, ">>");
+        TO_STRING_TT(TOKEN_REDIRECT, ">");
         TO_STRING_TT(TOKEN_ERROR, "<ERROR>");
         TO_STRING_TT(TOKEN_EOF, "<EOF>");
     }
@@ -53,9 +51,7 @@ const char* dump_token_type(enum TokenType type) {
         CASE_TT(TOKEN_NOT);
 
         CASE_TT(TOKEN_PIPE);
-        CASE_TT(TOKEN_REDIRECT_IN);
-        CASE_TT(TOKEN_REDIRECT_OUT);
-        CASE_TT(TOKEN_REDIRECT_APPEND);
+        CASE_TT(TOKEN_REDIRECT);
 
         CASE_TT(TOKEN_ERROR);
         CASE_TT(TOKEN_EOF);

--- a/src/repl.c
+++ b/src/repl.c
@@ -28,7 +28,6 @@ void run_repl(struct Repl* repl) {
 
         reset_parser(repl->line, &repl->parser);
         lexer_lex_full(repl->parser.lexer);
-        printf("???\n");
 
         const bool success = parse_program(&repl->parser);
 

--- a/src/repl.c
+++ b/src/repl.c
@@ -28,6 +28,7 @@ void run_repl(struct Repl* repl) {
 
         reset_parser(repl->line, &repl->parser);
         lexer_lex_full(repl->parser.lexer);
+        printf("???\n");
 
         const bool success = parse_program(&repl->parser);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -1,9 +1,11 @@
 #include <assert.h>
+#include <cash/ast.h>
 #include <cash/error.h>
 #include <cash/memory.h>
 #include <cash/string.h>
 #include <cash/util.h>
 #include <cash/vm.h>
+#include <fcntl.h>
 #include <linux/limits.h>
 #include <pwd.h>
 #include <stdbool.h>
@@ -11,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #define CHECK_ALLOC(ptr)                                                  \
@@ -24,10 +27,20 @@
 extern bool repl_mode;
 extern char *const *environ;
 
+struct RawRedirection {
+    int flags;
+    int left;
+    int right;
+    int err_to_out;
+    char *file_name;
+};
+
 struct RawCommand {
     char *name;
     char **args;
     int args_count;
+    struct RawRedirection *redirs;
+    int redirs_count;
 };
 static void free_raw_command(const struct RawCommand *raw_command);
 
@@ -40,12 +53,19 @@ static int flatten_pipeline(const struct Vm *vm, const struct Expr *expr,
                             struct Pipeline *pipeline);
 static void free_pipeline(const struct Pipeline *pipeline);
 
-static int spawn_process(int in, int out, const char *name, char *const *args);
+static int spawn_process(int in, int out, struct RawCommand *raw_command);
 
+static struct RawRedirection get_redirection(const struct Vm *vm,
+                                             const struct Redirection *redir);
 static int get_final_command(const struct Vm *vm, const struct Command *command,
                              struct RawCommand *raw_command);
 
 static int exec_expression(struct Vm *vm, struct Expr *expr);
+static pid_t run_raw_command(struct Vm *vm, struct RawCommand *raw_command,
+                             int in, int out);
+static pid_t run_raw_command_in_subshell(struct Vm *vm,
+                                         struct RawCommand *raw_command, int in,
+                                         int out);
 static int run_subshell(struct Vm *vm, struct Program *program);
 static int exec_pipeline(struct Vm *vm, struct Pipeline *pipeline);
 
@@ -56,7 +76,7 @@ static struct String to_string(const struct Vm *vm,
 
 static void update_prompt(struct Vm *vm);
 
-static void change_dir(struct Vm *vm, const struct Command *command);
+static void change_dir(struct Vm *vm, const struct RawCommand *command);
 
 static bool is_path(const char *cmd);
 static bool is_executable(const char *path);
@@ -92,6 +112,10 @@ static void free_raw_command(const struct RawCommand *raw_command) {
         free(raw_command->args[i]);
     }
     free(raw_command->args);
+    for (int i = 0; i < raw_command->redirs_count; ++i) {
+        free(raw_command->redirs[i].file_name);
+    }
+    free(raw_command->redirs);
 }
 
 static void free_pipeline(const struct Pipeline *pipeline) {
@@ -109,18 +133,262 @@ int run_program(struct Vm *vm, const struct Program *program) {
     return vm->previous_exit_code;
 }
 
-static int spawn_process(int in, int out, const char *name, char *const *args) {
-    printf("Spawing command: %s ", name);
-    for (int i = 0; args[i] != NULL; ++i) {
-        printf("%s ", args[i]);
-    }
-    printf("\n");
+static int spawn_process(int in, int out, struct RawCommand *raw_command) {
+    // printf("Spawing command: %s ", name);
+    // for (int i = 0; args[i] != NULL; ++i) {
+    //     printf("%s ", args[i]);
+    // }
+    // printf("\n");
     const pid_t pid = fork();
     if (pid < 0) {
-        CASH_PERROR(EXIT_FAILURE, "fork", "could not fork process %s", name);
+        CASH_PERROR(EXIT_FAILURE, "fork", "could not fork process %s",
+                    raw_command->name);
         return -1;
     }
 
+    if (pid == 0) {
+        for (int i = 0; i < raw_command->redirs_count; ++i) {
+            const struct RawRedirection *redir = &raw_command->redirs[i];
+            int left = redir->left;
+            int right = redir->right;
+            assert(left != -1);
+
+            if (redir->file_name == NULL) {
+                assert(right != -1);
+                if (dup2(right, left) == -1) {
+                    CASH_PERROR(EXIT_FAILURE, "dup2",
+                                "could not duplicate fd %d to %d", right, left);
+                    exit(EXIT_FAILURE);
+                }
+            } else {
+                assert(right == -1);
+                int fd = open(redir->file_name, redir->flags, 0644);
+                if (fd == -1) {
+                    CASH_PERROR(EXIT_FAILURE, "open", "could not open %s",
+                                redir->file_name);
+                    exit(EXIT_FAILURE);
+                }
+
+                right = fd;
+                if (dup2(right, left) == -1) {
+                    CASH_PERROR(EXIT_FAILURE, "dup2",
+                                "could not duplicate fd %d to %d", right, left);
+                    exit(EXIT_FAILURE);
+                }
+
+                close(fd);
+            }
+
+            if (redir->err_to_out) {
+                if (dup2(STDOUT_FILENO, STDERR_FILENO) == -1) {
+                    CASH_PERROR(EXIT_FAILURE, "dup2",
+                                "could not duplicate stdout to stderr");
+                    exit(EXIT_FAILURE);
+                }
+            }
+        }
+
+        const int res = execve(raw_command->name, raw_command->args, environ);
+        if (res == -1) {
+            CASH_PERROR(EXIT_FAILURE, "execvp", "could not execute %s",
+                        raw_command->name);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    return pid;
+}
+
+static int get_final_command(const struct Vm *vm, const struct Command *command,
+                             struct RawCommand *raw_command) {
+    char *executable = NULL;
+    char **args = NULL;
+    if (command->command_name.component_count != 0) {
+        const struct String command_name =
+            to_string(vm, &command->command_name);
+
+        printf("Name: %s\n", command_name.string);
+        args = malloc((command->arguments.argument_count + 2) * sizeof(*args));
+        if (!args) {
+            CASH_ERROR(EXIT_FAILURE,
+                       "could not allocate memory for arguments%s\n", "");
+            exit(EXIT_FAILURE);
+        }
+
+        args[0] = strndup(command_name.string, command_name.length);
+        printf("arg 0: (len %d) %s\n", command_name.length, args[0]);
+
+        for (int i = 0; i < command->arguments.argument_count; ++i) {
+            const struct String arg =
+                to_string(vm, &command->arguments.arguments[i]);
+            printf("arg %d: (len %d) %s\n", i + 1, arg.length, arg.string);
+
+            args[i + 1] = arg.string;
+        }
+        args[command->arguments.argument_count + 1] = NULL;
+        printf("-----------------\n");
+
+        if (is_path(command_name.string)) {
+            if (!is_executable(command_name.string)) {
+                CASH_ERROR(EXIT_FAILURE, "the path `%s` is not an executable\n",
+                           command_name.string);
+                free_string(&command_name);
+                return EXIT_FAILURE;
+            }
+            executable = strndup(command_name.string, command_name.length);
+        } else {
+            char *res = find_in_path(command_name.string);
+            if (res == NULL) {
+                executable = strndup(command_name.string, command_name.length);
+            } else {
+                executable = res;
+            }
+        }
+
+        free_string(&command_name);
+    }
+
+    struct RawRedirection *redirs =
+        malloc((command->redirection_count) * sizeof(struct RawRedirection));
+    CHECK_ALLOC(redirs);
+    for (int i = 0; i < command->redirection_count; ++i) {
+        struct Redirection *redir = &command->redirections[i];
+        redirs[i] = get_redirection(vm, redir);
+    }
+
+    *raw_command =
+        (struct RawCommand){.name = executable,
+                            .args = args,
+                            .args_count = command->arguments.argument_count + 1,
+                            .redirs_count = command->redirection_count,
+                            .redirs = redirs};
+
+    return 0;
+}
+
+static struct RawRedirection get_redirection(const struct Vm *vm,
+                                             const struct Redirection *redir) {
+    struct RawRedirection raw_redir = {
+        .left = redir->left,
+        .right = redir->right,
+        .err_to_out = false,
+        .file_name = NULL,
+        .flags = -1,
+    };
+    if (redir->file_name.component_count != 0) {
+        raw_redir.file_name = to_string(vm, &redir->file_name).string;
+    }
+
+    switch (redir->type) {
+        case REDIRECT_OUT:
+        case REDIRECT_OUTERR:
+            if (redir->left == -1)
+                raw_redir.left = STDOUT_FILENO;
+
+            raw_redir.flags = O_WRONLY | O_CREAT | O_TRUNC;
+            raw_redir.err_to_out = (redir->type == REDIRECT_OUTERR);
+            break;
+
+        case REDIRECT_IN:
+            if (redir->left == -1)
+                raw_redir.left = STDIN_FILENO;
+            raw_redir.flags = O_RDONLY;
+            break;
+
+        case REDIRECT_APPEND_OUT:
+        case REDIRECT_APPEND_OUTERR:
+            if (redir->left == -1)
+                raw_redir.left = STDOUT_FILENO;
+            raw_redir.flags = O_WRONLY | O_CREAT | O_APPEND;
+            raw_redir.err_to_out = (redir->type == REDIRECT_APPEND_OUTERR);
+            break;
+
+        case REDIRECT_OUT_DUPLICATE:
+            if (redir->left == -1)
+                raw_redir.left = STDOUT_FILENO;
+            assert(raw_redir.right != -1);
+            raw_redir.flags = O_WRONLY | O_CREAT | O_TRUNC;
+            break;
+
+        case REDIRECT_INOUT:
+            if (redir->left == -1)
+                raw_redir.left = STDIN_FILENO;
+            assert(redir->right == -1);
+            raw_redir.flags = O_RDWR | O_CREAT;
+            break;
+
+        default:
+            CASH_ERROR(EXIT_FAILURE, "unimplemented redirection type%s", "");
+            exit(EXIT_FAILURE);
+    }
+    return raw_redir;
+}
+
+int run_command(struct Vm *vm, struct Command *command, int in, int out) {
+    struct RawCommand raw_command;
+    const int command_expansion = get_final_command(vm, command, &raw_command);
+    if (command_expansion != 0) {
+        free_raw_command(&raw_command);
+        return command_expansion;
+    }
+
+    if (raw_command.name == NULL) {
+        if (raw_command.redirs_count == 0) {
+            free_raw_command(&raw_command);
+            return vm->previous_exit_code;
+        } else {
+            raw_command.name = strdup("/bin/true");
+            raw_command.args = malloc(2 * sizeof(char *));
+            CHECK_ALLOC(raw_command.args);
+            raw_command.args[0] = strdup("true");
+            raw_command.args[1] = NULL;
+            raw_command.args_count = 1;
+        }
+    }
+
+    int status;
+    pid_t pid = run_raw_command(vm, &raw_command, in, out);
+    waitpid(pid, &status, 0);
+    free_raw_command(&raw_command);
+
+    vm->previous_exit_code = status % 0xFF;
+    return vm->previous_exit_code;
+}
+
+static pid_t run_raw_command(struct Vm *vm, struct RawCommand *raw_command,
+                             int in, int out) {
+    // use custom implementation of cd and exit
+    if (strcmp(raw_command->name, "cd") == 0) {
+        change_dir(vm, raw_command);
+        return 0;
+    }
+
+    if (strcmp(raw_command->name, "exit") == 0) {
+        vm->exit = true;
+        return 0;
+    }
+
+    if (strcmp(raw_command->args[0], "ls") == 0) {
+        char *color_arg = malloc((strlen("--color=auto") + 1) * sizeof(char));
+        CHECK_ALLOC(color_arg);
+        strcpy(color_arg, "--color=auto");
+
+        char **new_args = realloc(
+            raw_command->args, (raw_command->args_count + 2) * sizeof(char *));
+        CHECK_ALLOC(new_args);
+        new_args[raw_command->args_count] = color_arg;
+        new_args[raw_command->args_count + 1] = NULL;
+        raw_command->args_count++;
+        raw_command->args = new_args;
+    }
+
+    return spawn_process(in, out, raw_command);
+}
+
+static pid_t run_raw_command_in_subshell(struct Vm *vm,
+                                         struct RawCommand *raw_command, int in,
+                                         int out) {
+    pid_t pid = fork();
     if (pid == 0) {
         if (in != STDIN_FILENO) {
             dup2(in, STDIN_FILENO);
@@ -130,123 +398,21 @@ static int spawn_process(int in, int out, const char *name, char *const *args) {
             dup2(out, STDOUT_FILENO);
             close(out);
         }
-        const int res = execve(name, args, environ);
-        if (res == -1) {
-            CASH_PERROR(EXIT_FAILURE, "execvp", "could not execute %s", name);
-        }
+
+        int status;
+        pid_t subpid =
+            run_raw_command(vm, raw_command, STDIN_FILENO, STDOUT_FILENO);
+        waitpid(subpid, &status, 0);
+        exit(status);
     }
 
     return pid;
 }
 
-static int get_final_command(const struct Vm *vm, const struct Command *command,
-                             struct RawCommand *raw_command) {
-    const struct String command_name = to_string(vm, &command->command_name);
-
-    printf("Name: %s\n", command_name.string);
-    char **args =
-        malloc((command->arguments.argument_count + 2) * sizeof(*args));
-    if (!args) {
-        CASH_ERROR(EXIT_FAILURE, "could not allocate memory for arguments%s\n",
-                   "");
-        exit(EXIT_FAILURE);
-    }
-
-    args[0] = strndup(command_name.string, command_name.length);
-    printf("arg 0: (len %d) %s\n", command_name.length, args[0]);
-
-    for (int i = 0; i < command->arguments.argument_count; ++i) {
-        const struct String arg =
-            to_string(vm, &command->arguments.arguments[i]);
-        printf("arg %d: (len %d) %s\n", i + 1, arg.length, arg.string);
-
-        args[i + 1] = arg.string;
-    }
-    args[command->arguments.argument_count + 1] = NULL;
-    printf("-----------------\n");
-
-    char *executable = NULL;
-    if (is_path(command_name.string)) {
-        if (!is_executable(command_name.string)) {
-            CASH_ERROR(EXIT_FAILURE, "the path `%s` is not an executable\n",
-                       command_name.string);
-            free_string(&command_name);
-            return EXIT_FAILURE;
-        }
-        executable = strndup(command_name.string, command_name.length);
-    } else {
-        char *res = find_in_path(command_name.string);
-        if (res == NULL) {
-            executable = strndup(command_name.string, command_name.length);
-        } else {
-            executable = res;
-        }
-    }
-
-    *raw_command = (struct RawCommand){
-        .name = executable,
-        .args = args,
-        .args_count = command->arguments.argument_count + 1};
-
-    free_string(&command_name);
-    return 0;
-}
-
-int run_command(struct Vm *vm, struct Command *command) {
-    int status;
-    struct RawCommand raw_command;
-    const int command_expansion = get_final_command(vm, command, &raw_command);
-    if (command_expansion != 0) {
-        free_raw_command(&raw_command);
-        return command_expansion;
-    }
-
-    // use custom implementation of cd and exit
-    if (strcmp(raw_command.name, "cd") == 0) {
-        change_dir(vm, command);
-        free_raw_command(&raw_command);
-        return 0;
-    }
-
-    if (strcmp(raw_command.name, "exit") == 0) {
-        vm->exit = true;
-        free_raw_command(&raw_command);
-        return 0;
-    }
-
-    // ls is changed to /usr/bin/ls, so need to check the original name entered
-    // by user temporary workaround, won't be needed when word splitting is
-    // added
-    const struct String command_name = to_string(vm, &command->command_name);
-    if (strcmp(command_name.string, "ls") == 0) {
-        char *color_arg = malloc((strlen("--color=auto") + 1) * sizeof(char));
-        CHECK_ALLOC(color_arg);
-        strcpy(color_arg, "--color=auto");
-
-        char **new_args = realloc(
-            raw_command.args, (raw_command.args_count + 2) * sizeof(char *));
-        CHECK_ALLOC(new_args);
-        new_args[raw_command.args_count] = color_arg;
-        new_args[raw_command.args_count + 1] = NULL;
-        raw_command.args_count++;
-        raw_command.args = new_args;
-    }
-    free_string(&command_name);
-
-    const pid_t pid = spawn_process(STDIN_FILENO, STDOUT_FILENO,
-                                    raw_command.name, raw_command.args);
-
-    waitpid(pid, &status, 0);
-    free_raw_command(&raw_command);
-
-    vm->previous_exit_code = status % 0xFF;
-    return status;
-}
-
 static int exec_expression(struct Vm *vm, struct Expr *expr) {
     switch (expr->type) {
         case EXPR_COMMAND:
-            return run_command(vm, &expr->command);
+            return run_command(vm, &expr->command, STDIN_FILENO, STDOUT_FILENO);
 
         case EXPR_SUBSHELL:
             return run_subshell(vm, expr->subshell);
@@ -314,7 +480,7 @@ static int run_subshell(struct Vm *vm, struct Program *program) {
 
 static int flatten_pipeline(const struct Vm *vm, const struct Expr *expr,
                             struct Pipeline *pipeline) {
-    struct RawCommand placeholder = {NULL, NULL, 0};
+    struct RawCommand placeholder = {NULL, NULL, 0, NULL, 0};
     if (expr->binary.left->type == EXPR_PIPELINE) {
         const int res = flatten_pipeline(vm, expr->binary.left, pipeline);
         if (res != 0)
@@ -342,16 +508,18 @@ static int exec_pipeline(struct Vm *vm, struct Pipeline *pipeline) {
     pid_t *pids = malloc(pipeline->command_count * sizeof(pid_t));
     int status;
     for (i = 0; i < pipeline->command_count - 1; ++i) {
-        const struct RawCommand *cmd = &pipeline->commands[i];
+        struct RawCommand *cmd = &pipeline->commands[i];
         pipe(pipefd);
-        pids[i] = spawn_process(in, pipefd[1], cmd->name, cmd->args);
+        pids[i] = run_raw_command_in_subshell(vm, cmd, in, pipefd[1]);
 
         close(pipefd[1]);
         in = pipefd[0];
     }
 
-    pids[i] = spawn_process(in, STDOUT_FILENO, pipeline->commands[i].name,
-                            pipeline->commands[i].args);
+    pids[i] = run_raw_command_in_subshell(vm, &pipeline->commands[i], in,
+                                          STDOUT_FILENO);
+    // (in, STDOUT_FILENO, pipeline->commands[i].name,
+    //                         pipeline->commands[i].args);
     waitpid(pids[i], &status, 0);
 
     for (i = 0; i < pipeline->command_count - 1; ++i) {
@@ -434,9 +602,9 @@ struct String expand_component(const struct Vm *vm,
     }
 }
 
-// TODO: can make expand_component write directly to a single allocated
-// string, instead of allocating a new one for each compoenent and then
-// freeing it
+// TODO: can make expand_component write directly to a single
+// allocated string, instead of allocating a new one for each
+// compoenent and then freeing it
 struct String to_string(const struct Vm *vm, const struct ShellString *string) {
     char *str = NULL;
     int total_size = 0;
@@ -444,13 +612,15 @@ struct String to_string(const struct Vm *vm, const struct ShellString *string) {
     for (int i = 0; i < string->component_count; ++i) {
         const struct String expanded =
             expand_component(vm, &string->components[i]);
-        // printf("expanded (%d): %.*s\n", expanded.length, expanded.length,
+        // printf("expanded (%d): %.*s\n", expanded.length,
+        // expanded.length,
         //        expanded.string);
         const int is_last_comp = i + 1 == string->component_count;
         const int new_alloc_size = total_size + expanded.length + is_last_comp;
         // printf("new alloc size: %d\n", new_alloc_size);
         str = grow_string(str, new_alloc_size);
-        // printf("copying at position %d in (%d) \"%.*s\"\n", total_size,
+        // printf("copying at position %d in (%d) \"%.*s\"\n",
+        // total_size,
         //        total_size, total_size, str);
         strncpy(&str[total_size], expanded.string, expanded.length);
         total_size += expanded.length;
@@ -475,40 +645,38 @@ static void update_prompt(struct Vm *vm) {
     vm->current_prompt = make_new_prompt(vm->userpw->pw_name);
 }
 
-static void change_dir(struct Vm *vm, const struct Command *command) {
-    if (command->arguments.argument_count > 1) {
+static void change_dir(struct Vm *vm, const struct RawCommand *command) {
+    if (command->args_count > 2) {
         CASH_ERROR(EXIT_FAILURE,
                    "cd: too many arguments (one expected, got %d)\n",
-                   command->arguments.argument_count);
+                   command->args_count - 1);
         return;
     }
     int result = 0;
 
     char *old_pwd = vm->old_pwd;
     vm->old_pwd = vm->pwd;
-    if (command->arguments.argument_count == 0) {
+    if (command->args_count == 1) {
         result = chdir(vm->userpw->pw_dir);
         vm->pwd = strdup(vm->userpw->pw_dir);
     } else {
-        const struct String arg =
-            to_string(vm, &command->arguments.arguments[0]);
-        if (strcmp(arg.string, "-") == 0) {
+        const char *arg = command->args[1];
+        if (strcmp(arg, "-") == 0) {
             result = chdir(old_pwd);
             vm->pwd = old_pwd;
             printf("%s\n", old_pwd);
             old_pwd = NULL;
         } else {
-            result = chdir(arg.string);
+            result = chdir(arg);
 
             char path[PATH_MAX + 1];
             char *resolved = realpath(".", path);
             if (!resolved) {
-                CASH_PERROR(EXIT_FAILURE, "realpath", "");
+                CASH_PERROR(EXIT_FAILURE, "realpath", "%s", "");
                 exit(EXIT_FAILURE);
             }
             vm->pwd = strdup(resolved);
         }
-        free_string(&arg);
     }
 
     setenv("OLDPWD", vm->old_pwd, 1);
@@ -516,7 +684,7 @@ static void change_dir(struct Vm *vm, const struct Command *command) {
     free(old_pwd);
 
     if (result == -1) {
-        CASH_PERROR(EXIT_FAILURE, "cd", "");
+        CASH_PERROR(EXIT_FAILURE, "cd", "%s", "");
         return;
     }
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the CaSH shell, including support for advanced shell features like redirections, environment variable expansion, and command piping. Additionally, it includes major updates to the lexer, parser, and abstract syntax tree (AST) to support these features. Below is a summary of the most important changes, grouped by theme.

### New Features in Shell Functionality:
* Updated `README.md` to reflect new shell capabilities, including handling `&&`, `||`, `!`, subshell execution, environment variable expansion (`), built-in commands (`cd`, `exit`), and advanced redirection and piping.

### Changes in Execution of Piped Commands
* Piped commands are now executed in a "subshell". 
* The piping happens on the subshell level, while the redirections happen on the level of the command being executed inside the subshell. 
* I don't know if this is how bash does it, but it reflects the expected behaviour of commands like
    ```shell
    echo text > file | cat
    ```
    where text goes into "file", and `cat` receives no input. 

### Abstract Syntax Tree (AST) Enhancements:
* Added `RedirectionType` enum and `Redirection` struct to represent redirection operations in the AST.
* Extended the `Command` struct to include redirection-related fields (`redirections`, `redirection_count`, `redirection_capacity`).
* Introduced a `print_redirection` function to display redirection details for debugging.

### Lexer Improvements:
* Added support for recognizing and tokenizing redirection syntax (e.g., `>`, `>>`, `<`, `>&`, etc.), including file descriptor duplication. [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R130-R214) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R314-R322)
* Enhanced `Lexer` struct with a `backtrack_position` field to support backtracking during tokenization. [[1]](diffhunk://#diff-cb9ebae7b89f20942f0f3beab430a4c2dee79ac628a18d31d98f491e92e0a16aR14) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R59)
* Introduced helper functions like `try_consume_number` and `make_redirection_token` to parse redirection details. [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L146-R235) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R314-R322)

### Parser Updates:
* Added a `handle_redirection` function to process redirection tokens and populate the `Command` struct during parsing.
* Updated the parser logic to handle redirection tokens and integrate them into the AST.

### Miscellaneous:
* Modified the `run_command` function in the virtual machine (`Vm`) to accept input and output file descriptors for executing commands with redirections.

