### PR TITLE
Job control

### DIFF
--- a/include/cash/ast.h
+++ b/include/cash/ast.h
@@ -4,6 +4,16 @@
 #include <cash/string.h>
 #include <stdbool.h>
 
+struct Program {
+    struct Stmt* statements;
+    int statement_count;
+    int statement_capacity;
+
+    const char* text;
+    int text_length;
+};
+struct Program make_program(void);
+
 enum RedirectionType {
     REDIRECT_IN,
     REDIRECT_OUT,
@@ -31,16 +41,22 @@ void add_argument(struct ArgumentList* list, struct ShellString arg);
 void free_arg_list(const struct ArgumentList* list);
 
 struct Command {
-    struct ShellString command_name;
-    struct ArgumentList arguments;
-
     struct Redirection* redirections;
     int redirection_count;
     int redirection_capacity;
+
+    union {
+        struct {
+            struct ShellString command_name;
+            struct ArgumentList arguments;
+        } as_cmd;
+        struct Program as_subshell;
+    };
+
+    bool is_subshell;
 };
 
 enum ExprType {
-    EXPR_SUBSHELL,
     EXPR_PIPELINE,
     EXPR_NOT,
     EXPR_AND,
@@ -54,8 +70,7 @@ struct Expr {
     struct StringView expr_text;
     bool background;
     union {
-        struct Program* subshell;  // EXPR_SUBSHELL
-        struct Command command;    // EXPR_COMMAND
+        struct Command command;  // EXPR_COMMAND
         struct {
             struct Expr* left;
             struct Expr* right;
@@ -69,12 +84,6 @@ struct Stmt {
 };
 void free_stmt(const struct Stmt* stmt);
 
-struct Program {
-    struct Stmt* statements;
-    int statement_count;
-    int statement_capacity;
-};
-struct Program make_program(void);
 void add_statement(struct Program* program, struct Stmt stmt);
 void free_program(const struct Program* program);
 
@@ -82,7 +91,7 @@ void free_program(const struct Program* program);
 void print_program(const struct Program* program, int indent);
 void print_statement(const struct Stmt* stmt, int indent);
 void print_expr(const struct Expr* expr, int indent);
-void print_command(const struct Command* command);
+void print_command(const struct Command* command, int indent);
 void print_redirection(const struct Redirection* redirection);
 #endif
 

--- a/include/cash/error.h
+++ b/include/cash/error.h
@@ -9,7 +9,7 @@
     do {                                                                    \
         fprintf(stderr,                                                     \
                 RED "cash:  Error: " fmt RESET __VA_OPT__(, ) __VA_ARGS__); \
-        if (!repl_mode)                                                     \
+        if (!is_repl_mode)                                                  \
             exit(status);                                                   \
     } while (0)
 
@@ -17,7 +17,7 @@
     do {                                                                     \
         fprintf(stderr, RED "cash:  Error: " fmt RESET RED "%s: %s\n" RESET, \
                 __VA_ARGS__ __VA_OPT__(, ) how, strerror(errno));            \
-        if (!repl_mode)                                                      \
+        if (!is_repl_mode)                                                   \
             exit(status);                                                    \
     } while (0)
 

--- a/include/cash/job_control.h
+++ b/include/cash/job_control.h
@@ -17,9 +17,17 @@ struct RawRedirection {
 };
 
 struct RawCommand {
-    char *name;
-    char **args;
-    int args_count;
+    bool is_subshell;
+
+    union {
+        struct {
+            char *name;
+            char **args;
+            int args_count;
+        } as_cmd;
+        struct Program as_subshell;
+    };
+
     struct RawRedirection *redirs;
     int redirs_count;
 };
@@ -67,9 +75,11 @@ void do_job_notification(struct Vm *vm);
 int list_jobs(struct Vm *vm, const struct RawCommand *raw_command);
 int fg(struct Vm *vm, const struct RawCommand *raw_command);
 
+void setup_redirections(struct RawCommand *raw_command);
 void launch_process(struct Vm *vm, struct Process *process, pid_t pgid,
                     pid_t pid, int in, int out, int err, bool foreground);
 void launch_job(struct Vm *vm, struct Job *job, bool foreground);
+void put_job_in_foreground(struct Vm *vm, struct Job *job, bool cont);
 
 void format_job_info(struct Job *job, const char *state, FILE *stream);
 

--- a/include/cash/util.h
+++ b/include/cash/util.h
@@ -5,9 +5,36 @@
 #include <pwd.h>
 
 #ifndef NDEBUG
-#define CASH_DEBUG(...) fprintf(stderr, __VA_ARGS__)
+
+static const char* debug_files[] = {"repl.c", "parser.c"};
+static const int debug_files_len = sizeof(debug_files) / sizeof(debug_files[0]);
+
+#define CASH_DEBUG(...)                                       \
+    do {                                                      \
+        for (int i = 0; i < debug_files_len; ++i) {           \
+            if (debug_files[i][0] == '*' ||                   \
+                strcmp(__FILE_NAME__, debug_files[i]) == 0) { \
+                fprintf(stderr, __VA_ARGS__);                 \
+                break;                                        \
+            }                                                 \
+        }                                                     \
+    } while (0)
+
+#define CASH_DEBUG_EXPR(expr)                                 \
+    do {                                                      \
+        for (int i = 0; i < debug_files_len; ++i) {           \
+            if (debug_files[i][0] == '*' ||                   \
+                strcmp(__FILE_NAME__, debug_files[i]) == 0) { \
+                (expr);                                       \
+                break;                                        \
+            }                                                 \
+        }                                                     \
+    } while (0)
 #else
 #define CASH_DEBUG(...) ((void)0)
+#define CASH_DEBUG_EXPR(expr) \
+    do {                      \
+    } while (0)
 #endif
 
 char* read_all_stdin(void);

--- a/include/cash/vm.h
+++ b/include/cash/vm.h
@@ -27,6 +27,8 @@ struct Vm {
     struct termios shell_term_state;
     bool repl_mode;
     bool notified_this_time;
+    bool is_subshell;
+    bool background;
 
     struct Job* job_list;
     struct Process* current_processes;
@@ -35,7 +37,7 @@ struct Vm {
     char** argv;
 };
 
-struct Vm make_vm(int argc, char** argv);
+struct Vm make_vm(int argc, char** argv, bool repl_mode, bool background);
 void free_vm(const struct Vm* vm);
 
 int run_program(struct Vm* vm, const struct Program* program);

--- a/src/ast.c
+++ b/src/ast.c
@@ -22,7 +22,7 @@ static const char *kIndents[] = {
 };
 #endif
 
-extern bool repl_mode;
+extern bool is_repl_mode;
 
 struct ArgumentList make_arg_list(void) {
     return (struct ArgumentList){
@@ -43,12 +43,12 @@ void free_arg_list(const struct ArgumentList *list) {
 void free_expr(const struct Expr *expr) {
     switch (expr->type) {
         case EXPR_COMMAND:
-            free_shell_string(&expr->command.command_name);
-            free_arg_list(&expr->command.arguments);
-            break;
-
-        case EXPR_SUBSHELL:
-            free_program(expr->subshell);
+            if (expr->command.is_subshell) {
+                free_program(&expr->command.as_subshell);
+            } else {
+                free_shell_string(&expr->command.as_cmd.command_name);
+                free_arg_list(&expr->command.as_cmd.arguments);
+            }
             break;
 
         case EXPR_PIPELINE:
@@ -130,12 +130,6 @@ void print_expr(const struct Expr *expr, int indent) {
     if (expr->background)
         fprintf(stderr, BOLD YELLOW "(background)" RESET);
     switch (expr->type) {
-        case EXPR_SUBSHELL:
-            fprintf(stderr, "Subshell( ");
-            print_program(expr->subshell, indent + 1);
-            fprintf(stderr, " )");
-            break;
-
         case EXPR_PIPELINE:
         case EXPR_AND:
         case EXPR_OR:
@@ -157,7 +151,7 @@ void print_expr(const struct Expr *expr, int indent) {
             break;
 
         case EXPR_COMMAND:
-            print_command(&expr->command);
+            print_command(&expr->command, indent + 1);
             break;
     }
 }
@@ -168,14 +162,22 @@ void print_statement(const struct Stmt *stmt, int indent) {
     fprintf(stderr, " )");
 }
 
-void print_command(const struct Command *command) {
-    fprintf(stderr, "Command(<args: %d> " BOLD CYAN,
-            command->arguments.argument_count);
-    print_string(&command->command_name);
-    fprintf(stderr, "%s" RESET, command->arguments.argument_count ? " " : "");
-    for (int i = 0; i < command->arguments.argument_count; ++i) {
-        print_string(&command->arguments.arguments[i]);
-        fprintf(stderr, " ");
+void print_command(const struct Command *command, int indent) {
+    if (command->is_subshell) {
+        fprintf(stderr, "Subshell( ");
+        print_program(&command->as_subshell, indent + 1);
+        fprintf(stderr, " )");
+    } else {
+        fprintf(stderr, "Command(<args: %d> " BOLD CYAN,
+                command->as_cmd.arguments.argument_count);
+        print_string(&command->as_cmd.command_name);
+        fprintf(stderr, "%s" RESET,
+                command->as_cmd.arguments.argument_count ? " " : "");
+
+        for (int i = 0; i < command->as_cmd.arguments.argument_count; ++i) {
+            print_string(&command->as_cmd.arguments.arguments[i]);
+            fprintf(stderr, " ");
+        }
     }
 
     for (int i = 0; i < command->redirection_count; ++i) {

--- a/src/job_control.c
+++ b/src/job_control.c
@@ -3,6 +3,7 @@
 #include <cash/error.h>
 #include <cash/job_control.h>
 #include <cash/string.h>
+#include <cash/util.h>
 #include <cash/vm.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -16,19 +17,20 @@
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>
+
+#include "cash/colors.h"
+
 #ifndef WAIT_ANY
 #define WAIT_ANY ((pid_t) - 1)
 #endif
 
-extern bool repl_mode;
+extern bool is_repl_mode;
 extern char **environ;
-
-static void setup_redirections(struct RawCommand *raw_command);
 
 static int mark_process_status(struct Vm *vm, pid_t pid, int status);
 
 static void wait_for_job(struct Vm *vm, struct Job *job);
-static void put_job_in_foreground(struct Vm *vm, struct Job *job, bool cont);
+// static void put_job_in_foreground(struct Vm *vm, struct Job *job, bool cont);
 static void put_job_in_background(struct Job *job, bool cont);
 
 static void mark_job_as_running(struct Job *job);
@@ -37,11 +39,13 @@ static void continue_job(struct Vm *vm, struct Job *job, bool foreground);
 static void format_job_info_if_bkg(struct Job *job, const char *state);
 
 void free_raw_command(const struct RawCommand *raw_command) {
-    free(raw_command->name);
-    for (int i = 0; i < raw_command->args_count; ++i) {
-        free(raw_command->args[i]);
+    if (!raw_command->is_subshell) {
+        free(raw_command->as_cmd.name);
+        for (int i = 0; i < raw_command->as_cmd.args_count; ++i) {
+            free(raw_command->as_cmd.args[i]);
+        }
+        free(raw_command->as_cmd.args);
     }
-    free(raw_command->args);
     for (int i = 0; i < raw_command->redirs_count; ++i) {
         free(raw_command->redirs[i].file_name);
     }
@@ -119,12 +123,12 @@ void format_job_info(struct Job *job, const char *state, FILE *stream) {
 }
 
 static void format_job_info_if_bkg(struct Job *job, const char *state) {
-    if (job->background && repl_mode) {
+    if (job->background && is_repl_mode) {
         format_job_info(job, state, stderr);
     }
 }
 
-static void setup_redirections(struct RawCommand *raw_command) {
+void setup_redirections(struct RawCommand *raw_command) {
     for (int i = 0; i < raw_command->redirs_count; ++i) {
         const struct RawRedirection *redir = &raw_command->redirs[i];
         int left = redir->left;
@@ -167,23 +171,42 @@ static void setup_redirections(struct RawCommand *raw_command) {
     }
 }
 
+static void handle_signal(int sig) {
+    CASH_DEBUG(RED "no way bruh %d (%s)\n" RESET, sig, strsignal(sig));
+    signal(sig, SIG_DFL);
+}
+
 void launch_process(struct Vm *vm, struct Process *process, pid_t pgid,
                     pid_t pid, int in, int out, int err, bool foreground) {
-    int builtin = is_builtin(process->raw_command.name);
+    CASH_DEBUG(YELLOW "launching process %d: %s in %p\n" RESET, getpid(),
+               process->raw_command.is_subshell
+                   ? "subshell"
+                   : process->raw_command.as_cmd.name,
+               (void *)vm);
+    int builtin = process->raw_command.is_subshell
+                      ? -1
+                      : is_builtin(process->raw_command.as_cmd.name);
     if (vm->repl_mode && builtin == -1) {
+        pid = getpid();
         if (pgid == 0) {
             pgid = pid;
         }
+        CASH_DEBUG(YELLOW "Setting process group to %d (pid: %d)\n" RESET, pgid,
+                   pid);
         setpgid(pid, pgid);
         if (foreground) {
+            CASH_DEBUG(MAGENTA
+                       "ain't nobody's fool (have set terminal to %d)\n" RESET,
+                       pid);
             tcsetpgrp(STDIN_FILENO, pgid);
+            CASH_DEBUG("phew\n");
         }
 
         signal(SIGINT, SIG_DFL);
         signal(SIGQUIT, SIG_DFL);
-        signal(SIGTTIN, SIG_DFL);
-        signal(SIGTTOU, SIG_DFL);
-        signal(SIGTSTP, SIG_DFL);
+        signal(SIGTTIN, handle_signal);
+        signal(SIGTTOU, handle_signal);
+        signal(SIGTSTP, handle_signal);
         signal(SIGCHLD, SIG_DFL);
     }
 
@@ -200,20 +223,41 @@ void launch_process(struct Vm *vm, struct Process *process, pid_t pgid,
         close(err);
     }
 
+    if (!foreground)
+        is_repl_mode = false;
+
+    CASH_DEBUG(
+        "now before launching, I have an admission to mak; the pgid of %d "
+        "is %d ",
+        getpid(), getpgid(getpid()));
     setup_redirections(&process->raw_command);
+
+    if (process->raw_command.is_subshell) {
+        struct Vm new_vm = make_vm(vm->argc, vm->argv, false, !foreground);
+        new_vm.shell_pgid = getpid();
+        new_vm.shell_term_state = vm->shell_term_state;
+        new_vm.is_subshell = true;
+
+        int res = run_program(&new_vm, &process->raw_command.as_subshell);
+        CASH_DEBUG(YELLOW "subshell returned %d\n" RESET, res);
+        exit(res);
+    }
 
     if (builtin != -1) {
         int res = BUILTIN_FUNCS[builtin](vm, &process->raw_command);
         exit(res);
     }
 
-    execve(process->raw_command.name, process->raw_command.args, environ);
+    execve(process->raw_command.as_cmd.name, process->raw_command.as_cmd.args,
+           environ);
     CASH_PERROR(EXIT_FAILURE, "execve",
-                "could not execute %s: ", process->raw_command.name);
+                "could not execute %s: ", process->raw_command.as_cmd.name);
     exit(EXIT_FAILURE);
 }
 
 void launch_job(struct Vm *vm, struct Job *job, bool foreground) {
+    CASH_DEBUG("job %p in vm %p (pid: %d)\n", (void *)job, (void *)vm,
+               getpid());
     struct Process *process;
     pid_t pid;
     int pipefd[2];
@@ -224,6 +268,9 @@ void launch_job(struct Vm *vm, struct Job *job, bool foreground) {
 
     for (process = job->first_process; process != NULL;
          process = process->next_process) {
+        if (process->raw_command.as_cmd.name == NULL) {
+            continue;  // skip empty commands
+        }
         if (process->next_process != NULL) {
             if (pipe(pipefd) == -1) {
                 CASH_PERROR(EXIT_FAILURE, "pipe",
@@ -245,7 +292,7 @@ void launch_job(struct Vm *vm, struct Job *job, bool foreground) {
                            foreground);
         } else {
             process->pid = pid;
-            if (repl_mode) {
+            if (vm->repl_mode) {
                 if (job->pgid == 0)
                     job->pgid = pid;
                 setpgid(pid, job->pgid);
@@ -262,7 +309,7 @@ void launch_job(struct Vm *vm, struct Job *job, bool foreground) {
 
     format_job_info_if_bkg(job, "launched");
 
-    if (!repl_mode) {
+    if (!vm->repl_mode) {
         if (!foreground) {
             fprintf(stderr,
                     YELLOW
@@ -288,9 +335,11 @@ static void wait_for_job(struct Vm *vm, struct Job *job) {
              !job_is_completed(job));
 }
 
-static void put_job_in_foreground(struct Vm *vm, struct Job *job, bool cont) {
+void put_job_in_foreground(struct Vm *vm, struct Job *job, bool cont) {
     job->background = false;
+    CASH_DEBUG(RED "handing it over to pgid %ld\n" RESET, (long)job->pgid);
     tcsetpgrp(STDIN_FILENO, job->pgid);
+    CASH_DEBUG(MAGENTA "this was done\n" RESET);
 
     if (cont) {
         tcsetattr(STDIN_FILENO, TCSADRAIN, &job->term_state);
@@ -298,11 +347,17 @@ static void put_job_in_foreground(struct Vm *vm, struct Job *job, bool cont) {
             CASH_PERROR(EXIT_FAILURE, "kill", "could not continue job %ld",
                         (long)job->pgid);
         }
+        CASH_DEBUG(GREEN "I have unkilled the job %ld (%s)\n" RESET,
+                   (long)job->pgid, job->command);
     }
 
     wait_for_job(vm, job);
+    CASH_DEBUG(MAGENTA "waiting has ended in job %p in vm %p\n" RESET,
+               (void *)job, (void *)vm);
+    CASH_DEBUG(RED "idhar??????\n" RESET);
     tcsetpgrp(STDIN_FILENO, vm->shell_pgid);
 
+    CASH_DEBUG(RED "ive set it bro\n" RESET);
     tcgetattr(STDIN_FILENO, &job->term_state);
     tcsetattr(STDIN_FILENO, TCSADRAIN, &vm->shell_term_state);
 }
@@ -341,8 +396,8 @@ static int mark_process_status(struct Vm *vm, pid_t pid, int status) {
                     process->completed = true;
                     if (WIFSIGNALED(status)) {
                         process->terminated = true;
-                        fprintf(stderr, "Process %ld terminated by signal %d\n",
-                                (long)pid, WTERMSIG(status));
+                        CASH_DEBUG("Process %ld terminated by signal %d\n",
+                                   (long)pid, WTERMSIG(status));
                     }
                 }
 
@@ -357,10 +412,13 @@ static int mark_process_status(struct Vm *vm, pid_t pid, int status) {
 
 int list_jobs(struct Vm *vm, const struct RawCommand *raw_command) {
     (void)raw_command;  // for now, does nothing; can be extended to handle the
-                        // normal options that can be passed
+    // normal options that can be passed
+    CASH_DEBUG(RED "lets see job list %p (null: %d) in vm %p\n" RESET,
+               (void *)vm->job_list, vm->job_list == NULL, (void *)vm);
     struct Job *job = vm->job_list;
 
     if (job == NULL) {
+        CASH_DEBUG("done\n");
         return 0;
     }
 
@@ -384,7 +442,7 @@ int list_jobs(struct Vm *vm, const struct RawCommand *raw_command) {
 }
 
 int fg(struct Vm *vm, const struct RawCommand *raw_command) {
-    if (!repl_mode) {
+    if (!vm->repl_mode) {
         CASH_ERROR(EXIT_FAILURE,
                    "fg: no job control in non-interactive mode%s\n", "");
         return 1;
@@ -395,18 +453,18 @@ int fg(struct Vm *vm, const struct RawCommand *raw_command) {
     }
 
     int job_id = -1;
-    if (raw_command->args_count > 1) {
+    if (raw_command->as_cmd.args_count > 1) {
         long n;
         char *end;
-        if (raw_command->args[1][0] == '%') {
-            n = strtol(raw_command->args[1] + 1, &end, 10);
+        if (raw_command->as_cmd.args[1][0] == '%') {
+            n = strtol(raw_command->as_cmd.args[1] + 1, &end, 10);
         } else {
-            n = strtol(raw_command->args[1], &end, 10);
+            n = strtol(raw_command->as_cmd.args[1], &end, 10);
         }
 
         if (*end != '\0' || n < 1 || n > INT_MAX) {
             CASH_ERROR(EXIT_FAILURE, "fg: invalid job id `%s`\n",
-                       raw_command->args[1]);
+                       raw_command->as_cmd.args[1]);
             return 1;
         }
         job_id = (int)n;
@@ -415,12 +473,15 @@ int fg(struct Vm *vm, const struct RawCommand *raw_command) {
     struct Job *job = job_id == -1 ? vm->job_list : get_job_by_id(vm, job_id);
     if (job == NULL) {
         CASH_ERROR(EXIT_FAILURE, "fg: no such job `%s`\n",
-                   raw_command->args_count > 1 ? raw_command->args[1] : "");
+                   raw_command->as_cmd.args_count > 1
+                       ? raw_command->as_cmd.args[1]
+                       : "");
         return 1;
     }
 
-    if (repl_mode)
-        printf("%s\n", job->command);
+    if (vm->repl_mode)
+        printf(RED "weeeeeewoooooooooweeeeeeeeeeeewooooooo %s\n" RESET,
+               job->command);
     continue_job(vm, job, true);
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -9,16 +9,19 @@
 #include <string.h>
 #include <unistd.h>
 
-bool repl_mode = false;
+bool is_repl_mode = false;
 
 int main(const int argc, char* argv[]) {
+    // repl_mode = false;
+    // run_string("(cd; ls; sleep 2; pwd)", 0, argv);
+    // return 0;
     if (argc == 1) {
         if (!isatty(STDIN_FILENO)) {
             char* input = read_all_stdin();
             run_string(input, 0, argv);
             free(input);
         } else {
-            repl_mode = true;
+            is_repl_mode = true;
             struct Repl repl = make_repl(0, argv);
             run_repl(&repl);
             free_repl(&repl);
@@ -30,7 +33,7 @@ int main(const int argc, char* argv[]) {
                 return EXIT_FAILURE;
             }
 
-            repl_mode = false;
+            is_repl_mode = false;
             run_string(argv[2], 0, argv);
         } else {
             run_file(argv[1], argc - 2, argv + 1);

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -11,7 +11,7 @@
 #include "cash/ast.h"
 #include "cash/memory.h"
 
-extern bool repl_mode;
+extern bool is_repl_mode;
 
 static char peek(const struct Lexer* lexer);
 static char peek_next(const struct Lexer* lexer);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -9,6 +9,7 @@
 #include "cash/ast.h"
 #include "cash/error.h"
 #include "cash/memory.h"
+#include "cash/util.h"
 
 #define ALLOC_CHECKED(ptr, size)                                          \
     do {                                                                  \
@@ -27,7 +28,7 @@
         }                 \
     } while (0)
 
-extern bool repl_mode;
+extern bool is_repl_mode;
 
 static struct Parser make_subparser(const struct Parser* parser);
 
@@ -39,7 +40,7 @@ static struct Token advance(struct Parser* parser);
 static bool match(struct Parser* parser, enum TokenType type);
 static struct Token consume(enum TokenType type, struct Parser* parser);
 
-static bool parse_subshell(struct Parser* parser, struct Expr* expr);
+static bool parse_subshell(struct Parser* parser, struct Program* program);
 static bool parse_terminal(struct Parser* parser, struct Expr* expr);
 static bool parse_not_expr(struct Parser* parser, struct Expr* expr);
 static bool parse_pipeline(struct Parser* parser, struct Expr* expr);
@@ -110,6 +111,28 @@ static bool skip_line_terminator(struct Parser* parser) {
     return !parser->error;
 }
 
+#define ASSERT_NON_EMPTY_COMMAND(expr, msg)                                 \
+    do {                                                                    \
+        if ((expr)->type == EXPR_COMMAND && !(expr)->command.is_subshell && \
+            (expr)->command.as_cmd.command_name.component_count == 0 &&     \
+            (expr)->command.redirection_count == 0) {                       \
+            parser->error = true;                                           \
+            CASH_ERROR(EXIT_FAILURE, msg "%s", "");                         \
+            return false;                                                   \
+        }                                                                   \
+    } while (0)
+
+#define ASSERT_NON_EMPTY_COMMAND_BY_CONSUME(expr, parser, tok_type)         \
+    do {                                                                    \
+        if ((expr)->type == EXPR_COMMAND && !(expr)->command.is_subshell && \
+            (expr)->command.as_cmd.command_name.component_count == 0 &&     \
+            (expr)->command.redirection_count == 0) {                       \
+            parser->error = true;                                           \
+            consume(tok_type, parser);                                      \
+            return false;                                                   \
+        }                                                                   \
+    } while (0)
+
 static bool parse_expr(struct Parser* parser, struct Expr* expr) {
     struct Expr left_expr;
     struct Expr *left, *right;
@@ -117,6 +140,8 @@ static bool parse_expr(struct Parser* parser, struct Expr* expr) {
     const char* end;
 
     CHECK(parse_not_expr(parser, &left_expr));
+    begin = left_expr.expr_text.string;
+
     if (match(parser, TOKEN_AMP)) {
         left_expr.background = true;
         *expr = left_expr;
@@ -125,14 +150,7 @@ static bool parse_expr(struct Parser* parser, struct Expr* expr) {
 
     while (peek_tt(parser) == TOKEN_AND || peek_tt(parser) == TOKEN_OR) {
         const struct Token tok = advance(parser);
-        if (left_expr.type == EXPR_COMMAND &&
-            left_expr.command.command_name.component_count == 0 &&
-            left_expr.command.redirection_count == 0) {
-            // error
-            parser->error = true;
-            CASH_ERROR(EXIT_FAILURE, "empty command in AND/OR list\n%s", "");
-            return false;
-        }
+        ASSERT_NON_EMPTY_COMMAND(&left_expr, "empty command in AND/OR list\n");
 
         if (begin == NULL)
             begin = tok.lexeme;
@@ -142,14 +160,7 @@ static bool parse_expr(struct Parser* parser, struct Expr* expr) {
         CHECK(parse_not_expr(parser, right));
         end = right->expr_text.string + right->expr_text.length;
 
-        if (right->type == EXPR_COMMAND &&
-            right->command.command_name.component_count == 0 &&
-            right->command.redirection_count == 0) {
-            // error
-            parser->error = true;
-            CASH_ERROR(EXIT_FAILURE, "empty command in AND/OR list\n%s", "");
-            return false;
-        }
+        ASSERT_NON_EMPTY_COMMAND(right, "empty command in AND/OR list\n");
 
         *left = left_expr;
         left_expr =
@@ -159,7 +170,25 @@ static bool parse_expr(struct Parser* parser, struct Expr* expr) {
                           .background = false};
     }
 
-    left_expr.background = match(parser, TOKEN_AMP);
+    if (match(parser, TOKEN_AMP) &&
+        (left_expr.type == EXPR_AND || left_expr.type == EXPR_OR)) {
+        struct Stmt stmt = {left_expr};
+        struct Program subshell = make_program();
+        subshell.text = left_expr.expr_text.string;
+        subshell.text_length = left_expr.expr_text.length;
+        add_statement(&subshell, stmt);
+
+        left_expr = (struct Expr){.type = EXPR_COMMAND,
+                                  .expr_text = left_expr.expr_text,
+                                  .background = true,
+                                  .command = (struct Command){
+                                      .is_subshell = true,
+                                      .as_subshell = subshell,
+                                      .redirections = NULL,
+                                      .redirection_count = 0,
+                                      .redirection_capacity = 0,
+                                  }};
+    }
     *expr = left_expr;
     return true;
 }
@@ -171,12 +200,7 @@ static bool parse_not_expr(struct Parser* parser, struct Expr* expr) {
 
     CHECK(parse_pipeline(parser, &sub_expr));
     if (is_not_expr) {
-        if (sub_expr.type == EXPR_COMMAND &&
-            sub_expr.command.command_name.component_count == 0 &&
-            sub_expr.command.redirection_count == 0) {
-            // error
-            consume(TOKEN_WORD, parser);
-        }
+        ASSERT_NON_EMPTY_COMMAND_BY_CONSUME(&sub_expr, parser, TOKEN_WORD);
 
         struct Expr* not_expr;
         ALLOC_CHECKED(not_expr, sizeof(struct Expr));
@@ -200,32 +224,19 @@ static bool parse_pipeline(struct Parser* parser, struct Expr* expr) {
     CHECK(parse_terminal(parser, &left_expr));
 
     while (match(parser, TOKEN_PIPE)) {
-        if (left_expr.type == EXPR_COMMAND &&
-            left_expr.command.command_name.component_count == 0 &&
-            left_expr.command.redirection_count == 0) {
-            // error
-            parser->error = true;
-            CASH_ERROR(EXIT_FAILURE, "empty command in pipeline\n%s", "");
-            return false;
-        }
-
         struct Expr *left, *right;
         ALLOC_CHECKED(left, sizeof(struct Expr));
+        *left = left_expr;
+
+        ASSERT_NON_EMPTY_COMMAND(left, "empty command in pipeline\n");
+
         ALLOC_CHECKED(right, sizeof(struct Expr));
 
         CHECK(parse_terminal(parser, right));
         end = right->expr_text.string + right->expr_text.length;
 
-        if (right->type == EXPR_COMMAND &&
-            right->command.command_name.component_count == 0 &&
-            right->command.redirection_count == 0) {
-            // error
-            parser->error = true;
-            CASH_ERROR(EXIT_FAILURE, "empty command in pipeline\n%s", "");
-            return false;
-        }
+        ASSERT_NON_EMPTY_COMMAND(right, "empty command in pipeline\n");
 
-        *left = left_expr;
         left_expr = (struct Expr){.type = EXPR_PIPELINE,
                                   .binary = {.left = left, .right = right},
                                   .expr_text = {begin, end - begin},
@@ -237,19 +248,12 @@ static bool parse_pipeline(struct Parser* parser, struct Expr* expr) {
 }
 
 static bool parse_terminal(struct Parser* parser, struct Expr* expr) {
-    if (peek_tt(parser) == TOKEN_LPAREN) {
-        return parse_subshell(parser, expr);
-    }
     return parse_command(parser, expr);
 }
 
-static bool parse_subshell(struct Parser* parser, struct Expr* expr) {
-    const char* begin = peek(parser).lexeme;
-    const char* end;
-
-    advance(parser);
+static bool parse_subshell(struct Parser* parser, struct Program* program) {
+    const char* begin = advance(parser).lexeme;
     struct Parser subparser = make_subparser(parser);
-    struct Program* subshell;
 
     if (!parse_program(&subparser)) {
         parser->error = true;
@@ -258,32 +262,43 @@ static bool parse_subshell(struct Parser* parser, struct Expr* expr) {
 
     parser->current_token = subparser.current_token;
     parser->next_token = subparser.next_token;
-    struct Token rparen = consume(TOKEN_RPAREN, parser);  // consume ')'
-    end = rparen.lexeme + rparen.lexeme_length;
+
+    const struct Token rparen = consume(TOKEN_RPAREN, parser);
+    const char* end = rparen.lexeme + rparen.lexeme_length;
 
     if (parser->error)
         return false;
 
-    ALLOC_CHECKED(subshell, sizeof(struct Program));
-    *subshell = subparser.program;
-    *expr = (struct Expr){.type = EXPR_SUBSHELL,
-                          .subshell = subshell,
-                          .background = false,
-                          .expr_text = {begin, end - begin}};
+    *program = subparser.program;
+    program->text = begin;
+    program->text_length = end - begin;
     return true;
 }
 
 static bool parse_command(struct Parser* parser, struct Expr* expr) {
-    struct Command command = {.command_name = {.components = NULL,
-                                               .component_count = 0,
-                                               .component_capacity = 0},
-                              .arguments = make_arg_list(),
+    struct Command command = {.is_subshell = false,
                               .redirection_capacity = 0,
                               .redirection_count = 0,
                               .redirections = NULL};
     bool break_out = false;
     const char* begin = peek(parser).lexeme;
-    const char* end;
+    const char* end = NULL;
+
+    if (peek_tt(parser) == TOKEN_LPAREN) {
+        command.is_subshell = true;
+        struct Program program;
+        if (!parse_subshell(parser, &program)) {
+            parser->error = true;
+            return false;
+        }
+        command.as_subshell = program;
+        begin = program.text;
+        end = program.text + program.text_length;
+    } else {
+        command.as_cmd.command_name = (struct ShellString){
+            .components = NULL, .component_count = 0, .component_capacity = 0};
+        command.as_cmd.arguments = make_arg_list();
+    }
 
     while (!is_at_end(parser) && !break_out) {
         if (parser->error)
@@ -292,15 +307,23 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
         const struct Token next = peek(parser);
         switch (next.type) {
             case TOKEN_WORD: {
+                if (command.is_subshell) {
+                    CASH_ERROR(EXIT_FAILURE, "unexpected token `%.*s`",
+                               next.lexeme_length, next.lexeme);
+                    parser->error = true;
+                    return false;
+                }
                 end = next.lexeme + next.lexeme_length;
-                if (command.command_name.component_count == 0) {
-                    command.command_name = advance(parser).value.word;
+                if (command.as_cmd.command_name.component_count == 0) {
+                    command.as_cmd.command_name = advance(parser).value.word;
                 } else {
                     const struct Token argument = advance(parser);
-                    add_argument(&command.arguments, argument.value.word);
+                    add_argument(&command.as_cmd.arguments,
+                                 argument.value.word);
                 }
                 break;
             }
+
             case TOKEN_RPAREN:
                 if (parser->is_subparser)
                     break_out = true;
@@ -323,7 +346,8 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
                 parser->error = true;
                 return false;
             default:
-                CASH_ERROR(EXIT_FAILURE, "IMPOSSIBLE%s", "");
+                CASH_ERROR(EXIT_FAILURE, "unexpected token `%.*s`",
+                           next.lexeme_length, next.lexeme);
                 exit(EXIT_FAILURE);
         }
     }
@@ -331,10 +355,12 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
     if (parser->error)
         return false;
 
-    *expr = (struct Expr){.type = EXPR_COMMAND,
-                          .command = command,
-                          .background = false,
-                          .expr_text = {begin, end - begin}};
+    *expr = (struct Expr){
+        .type = EXPR_COMMAND,
+        .command = command,
+        .background = false,
+        .expr_text = end == NULL ? (struct StringView){begin, 0}
+                                 : (struct StringView){begin, end - begin}};
     return true;
 }
 
@@ -367,7 +393,7 @@ static bool parse_statement(struct Parser* parser, struct Stmt* stmt) {
     *stmt = (struct Stmt){.expr = expr};
 
     if (stmt->expr.type == EXPR_COMMAND &&
-        stmt->expr.command.command_name.component_count == 0 &&
+        stmt->expr.command.as_cmd.command_name.component_count == 0 &&
         stmt->expr.command.redirection_count == 0) {
         bool skipped = skip_line_terminator(parser);
         if (!is_at_end(parser)) {

--- a/src/repl.c
+++ b/src/repl.c
@@ -17,7 +17,7 @@ static bool get_line(struct Repl* repl);
 
 struct Repl make_repl(int argc, char** argv) {
     return (struct Repl){.parser = parser_new("", true),
-                         .vm = make_vm(argc, argv),
+                         .vm = make_vm(argc, argv, true, false),
                          .line = NULL};
 }
 
@@ -40,7 +40,7 @@ void run_repl(struct Repl* repl) {
         if (success) {
 #ifndef NDEBUG
             print_program(&program, 0);
-            printf("\n");
+            CASH_DEBUG("\n");
 #endif
 
             run_program(&repl->vm, &program);
@@ -60,11 +60,22 @@ void free_repl(const struct Repl* repl) {
     free_vm(&repl->vm);
 }
 
+static bool is_empty(const char* line) {
+    while (*line) {
+        if (!isspace((unsigned char)*line)) {
+            return false;
+        }
+        line++;
+    }
+    return true;
+}
+
 static bool get_line(struct Repl* repl) {
     free(repl->line);
     repl->line = readline(repl->vm.current_prompt);
     if (repl->line) {
-        add_history(repl->line);
+        if (!is_empty(repl->line))
+            add_history(repl->line);
         return true;
     }
     return false;

--- a/src/string.c
+++ b/src/string.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern bool repl_mode;
+extern bool is_repl_mode;
 
 static void add_component(struct ShellString *str,
                           struct StringComponent comp) {

--- a/src/util.c
+++ b/src/util.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <unistd.h>
 extern char **environ;
-extern bool repl_mode;
+extern bool is_repl_mode;
 
 const struct passwd *get_pw(void) {
     const struct passwd *pw = getpwuid(getuid());
@@ -37,11 +37,12 @@ char *get_cwd(void) {
 
 char *make_new_prompt(const char *username) {
     char *cwd = get_cwd();
-    const size_t size_needed =
-        strlen(username) + strlen(cwd) + COLOR_ATTR_LEN * 4 + COLOR_LEN * 2 + 3;
+    const size_t size_needed = strlen(username) + strlen(cwd) +
+                               COLOR_ATTR_LEN * 4 + COLOR_LEN * 2 +
+                               3 /* ':$ ' */ + 6 /* (cash) */;
     char *buf = malloc(size_needed * sizeof(char));
-    sprintf(buf, BOLD GREEN "%s" RESET ":" BOLD BLUE "%s" RESET "$ ", username,
-            cwd);
+    sprintf(buf, BOLD GREEN "(cash)%s" RESET ":" BOLD BLUE "%s" RESET "$ ",
+            username, cwd);
 
     free(cwd);
     return buf;
@@ -154,7 +155,7 @@ char *read_file(const char *path) {
 }
 
 void run_string(const char *text, int argc, char **argv) {
-    struct Vm vm = make_vm(argc, argv);
+    struct Vm vm = make_vm(argc, argv, false, false);
     struct Parser parser = parser_new(text, false);
     parse_program(&parser);
     const struct Program prog = parser.program;

--- a/src/vm.c
+++ b/src/vm.c
@@ -27,23 +27,25 @@
         }                                                                 \
     } while (0)
 
-extern bool repl_mode;
+extern bool is_repl_mode;
 extern char **environ;
 
-static void make_process(struct Vm *vm, const struct Command *command,
+static void make_process(struct Vm *vm, struct Command *command,
                          struct Process *process);
-static int make_process_list(struct Vm *vm, const struct Expr *expr,
+static int make_process_list(struct Vm *vm, struct Expr *expr,
                              struct Process ***process_list);
-static int make_job(struct Vm *vm, const struct Expr *expr, struct Job *job);
+static int make_job(struct Vm *vm, struct Expr *expr, struct Job *job);
 
 static struct RawRedirection get_redirection(const struct Vm *vm,
                                              const struct Redirection *redir);
-static int get_final_command(const struct Vm *vm, const struct Command *command,
+static int get_final_command(const struct Vm *vm, struct Command *command,
                              struct RawCommand *raw_command);
 
-static int exec_expression(struct Vm *vm, struct Expr *expr);
-static int run_command(struct Vm *vm, struct Expr *expr);
-static int run_subshell(struct Vm *vm, struct Program *program);
+static int exec_expression(struct Vm *vm, struct Expr *expr, struct Job **job);
+
+static void backup_fds(int *saved_in, int *saved_out, int *saved_err);
+static void restore_fds(int saved_in, int saved_out, int saved_err);
+static int run_command(struct Vm *vm, struct Expr *expr, struct Job **job);
 
 static struct String expand_component(const struct Vm *vm,
                                       const struct StringComponent *component);
@@ -74,34 +76,44 @@ const char *BUILTIN_NAMES[] = {"cd", "exit", "jobs", "fg"};
 const BuiltinFunc BUILTIN_FUNCS[] = {change_dir, exit_shell, list_jobs, fg};
 const int BUILTIN_COUNT = sizeof(BUILTIN_NAMES) / sizeof(BUILTIN_NAMES[0]);
 
-struct Vm make_vm(int argc, char **argv) {
+static void handle_signal(int sig) {
+    CASH_DEBUG(RED "yo %d (%s) (pid: %d) (control with: %d)\n" RESET, sig,
+               strsignal(sig), getpid(), tcgetpgrp(STDIN_FILENO));
+    signal(sig, SIG_IGN);
+}
+
+struct Vm make_vm(int argc, char **argv, bool repl_mode, bool background) {
     struct passwd *userpw = getpwuid(getuid());
     char *cwd = get_cwd();
 
-    pid_t shell_pgid;
+    pid_t shell_pgid = 0;
+    struct termios term_state = {0};
+    // assert(!background || !repl_mode);
     if (repl_mode) {
         while (tcgetpgrp(STDIN_FILENO) != (shell_pgid = getpgrp())) {
             kill(-shell_pgid, SIGTTIN);
         }
+
+        signal(SIGINT, handle_signal);
+        signal(SIGQUIT, handle_signal);
+        signal(SIGTTOU, handle_signal);
+        signal(SIGSTOP, handle_signal);
+        signal(SIGTSTP, handle_signal);
+        signal(SIGTTIN, handle_signal);
+        signal(SIGCHLD, SIG_DFL);
+
+        shell_pgid = getpid();
+        if (setpgid(shell_pgid, shell_pgid) == -1) {
+            CASH_PERROR(EXIT_FAILURE, "setpgid",
+                        "could not set process group id%s", "");
+            exit(EXIT_FAILURE);
+        }
+
+        if (!background) {
+            tcsetpgrp(STDIN_FILENO, shell_pgid);
+        }
+        tcgetattr(STDIN_FILENO, &term_state);
     }
-
-    signal(SIGINT, SIG_IGN);
-    signal(SIGQUIT, SIG_IGN);
-    signal(SIGTTOU, SIG_IGN);
-    signal(SIGTSTP, SIG_IGN);
-    signal(SIGTTIN, SIG_IGN);
-    signal(SIGCHLD, SIG_DFL);
-
-    shell_pgid = getpid();
-    if (setpgid(shell_pgid, shell_pgid) == -1) {
-        CASH_PERROR(EXIT_FAILURE, "setpgid", "could not set process group id%s",
-                    "");
-        exit(EXIT_FAILURE);
-    }
-
-    tcsetpgrp(STDIN_FILENO, shell_pgid);
-    struct termios term_state;
-    tcgetattr(STDIN_FILENO, &term_state);
 
     setenv("PWD", cwd, 1);
     setenv("OLDPWD", cwd, 1);
@@ -118,6 +130,7 @@ struct Vm make_vm(int argc, char **argv) {
         .repl_mode = repl_mode,
         .shell_pgid = shell_pgid,
         .shell_term_state = term_state,
+        .is_subshell = false,
 
         .argc = argc,
         .argv = argv,
@@ -137,10 +150,42 @@ void free_vm(const struct Vm *vm) {
 }
 
 int run_program(struct Vm *vm, const struct Program *program) {
+    CASH_DEBUG(YELLOW "running program in vm %p (pid: %d)" RESET, (void *)vm,
+               getpid());
+    CASH_DEBUG_EXPR(print_program(program, 0));
+    CASH_DEBUG("\n");
+
     for (int i = 0; i < program->statement_count; ++i) {
-        exec_expression(vm, &program->statements[i].expr);
+        struct Job *job = NULL;
+
+        CASH_DEBUG("expr %d", i);
+        CASH_DEBUG_EXPR(print_expr(&program->statements[i].expr, 0));
+        CASH_DEBUG("\n");
+        int res = exec_expression(vm, &program->statements[i].expr, &job);
+        CASH_DEBUG("expr has been execed with %d\n", res);
+
+        if (vm->is_subshell) {
+            if (vm->job_list != job)
+                continue;
+            // while (!job_is_completed(job) && job_is_stopped(job)) {
+            //     CASH_DEBUG(RED "sombody help me\n" RESET);
+            //     kill(-vm->shell_pgid, SIGSTOP);
+            //     put_job_in_foreground(vm, job, true);
+            //     CASH_DEBUG(RED "aaaaaaaaaaaaaaah\n" RESET);
+            //     do_job_notification(vm);
+            //     break;
+            // }
+        }
+
+        if (i + 1 < program->statement_count) {
+            CASH_DEBUG("next one is %d (exit: %d)\n", i + 1, vm->exit);
+            CASH_DEBUG_EXPR(print_expr(&program->statements[i + 1].expr, 0));
+            CASH_DEBUG("\n");
+        }
         // run_command(vm, &program->statements[i].command);
     }
+    if (vm->is_subshell)
+        exit(vm->previous_exit_code);
 
     if (!vm->notified_this_time)
         do_job_notification(vm);
@@ -148,53 +193,79 @@ int run_program(struct Vm *vm, const struct Program *program) {
     return vm->previous_exit_code;
 }
 
-static int get_final_command(const struct Vm *vm, const struct Command *command,
+static int get_final_command(const struct Vm *vm, struct Command *command,
                              struct RawCommand *raw_command) {
-    char *executable = NULL;
-    char **args = NULL;
-    if (command->command_name.component_count != 0) {
-        const struct String command_name =
-            to_string(vm, &command->command_name);
+    if (command->is_subshell) {
+        *raw_command = (struct RawCommand){.is_subshell = true,
+                                           .as_subshell = command->as_subshell};
+    } else {
+        char *executable = NULL;
+        char **args = NULL;
 
-        CASH_DEBUG("Name: %s\n", command_name.string);
-        args = malloc((command->arguments.argument_count + 2) * sizeof(*args));
-        if (!args) {
-            CASH_ERROR(EXIT_FAILURE,
-                       "could not allocate memory for arguments%s\n", "");
-            exit(EXIT_FAILURE);
-        }
+        if (command->as_cmd.command_name.component_count != 0) {
+            const struct String command_name =
+                to_string(vm, &command->as_cmd.command_name);
+            CASH_DEBUG("Name: %s\n", command_name.string);
 
-        args[0] = strndup(command_name.string, command_name.length);
-        CASH_DEBUG("arg 0: (len %d) %s\n", command_name.length, args[0]);
-
-        for (int i = 0; i < command->arguments.argument_count; ++i) {
-            const struct String arg =
-                to_string(vm, &command->arguments.arguments[i]);
-            CASH_DEBUG("arg %d: (len %d) %s\n", i + 1, arg.length, arg.string);
-
-            args[i + 1] = arg.string;
-        }
-        args[command->arguments.argument_count + 1] = NULL;
-        CASH_DEBUG("-----------------\n");
-
-        if (is_path(command_name.string)) {
-            if (!is_executable(command_name.string)) {
-                CASH_ERROR(EXIT_FAILURE, "the path `%s` is not an executable\n",
-                           command_name.string);
-                free_string(&command_name);
-                return EXIT_FAILURE;
+            if (strcmp(command_name.string, "ls") == 0) {
+                struct ShellString new_arg = {.components = NULL,
+                                              .component_count = 0,
+                                              .component_capacity = 0};
+                add_string_literal(&new_arg, STRING_COMPONENT_LITERAL,
+                                   "--color=auto", strlen("--color=auto"), 0);
+                add_argument(&command->as_cmd.arguments, new_arg);
             }
-            executable = strndup(command_name.string, command_name.length);
-        } else {
-            char *res = find_in_path(command_name.string);
-            if (res == NULL) {
+
+            args = malloc((command->as_cmd.arguments.argument_count + 2) *
+                          sizeof(*args));
+            if (!args) {
+                CASH_ERROR(EXIT_FAILURE,
+                           "could not allocate memory for arguments%s\n", "");
+                exit(EXIT_FAILURE);
+            }
+
+            args[0] = strndup(command_name.string, command_name.length);
+            CASH_DEBUG("arg 0: (len %d) %s\n", command_name.length, args[0]);
+
+            for (int i = 0; i < command->as_cmd.arguments.argument_count; ++i) {
+                const struct String arg =
+                    to_string(vm, &command->as_cmd.arguments.arguments[i]);
+                CASH_DEBUG("arg %d: (len %d) %s\n", i + 1, arg.length,
+                           arg.string);
+
+                args[i + 1] = arg.string;
+            }
+            args[command->as_cmd.arguments.argument_count + 1] = NULL;
+            CASH_DEBUG("-----------------\n");
+
+            if (is_path(command_name.string)) {
+                if (!is_executable(command_name.string)) {
+                    CASH_ERROR(EXIT_FAILURE,
+                               "the path `%s` is not an executable\n",
+                               command_name.string);
+                    free_string(&command_name);
+                    return EXIT_FAILURE;
+                }
                 executable = strndup(command_name.string, command_name.length);
             } else {
-                executable = res;
+                char *res = find_in_path(command_name.string);
+                if (res == NULL) {
+                    executable =
+                        strndup(command_name.string, command_name.length);
+                } else {
+                    executable = res;
+                }
             }
+
+            free_string(&command_name);
         }
 
-        free_string(&command_name);
+        *raw_command = (struct RawCommand){
+            .is_subshell = false,
+            .as_cmd = {
+                .name = executable,
+                .args = args,
+                .args_count = command->as_cmd.arguments.argument_count + 1}};
     }
 
     struct RawRedirection *redirs =
@@ -205,12 +276,8 @@ static int get_final_command(const struct Vm *vm, const struct Command *command,
         redirs[i] = get_redirection(vm, redir);
     }
 
-    *raw_command =
-        (struct RawCommand){.name = executable,
-                            .args = args,
-                            .args_count = command->arguments.argument_count + 1,
-                            .redirs_count = command->redirection_count,
-                            .redirs = redirs};
+    raw_command->redirs_count = command->redirection_count;
+    raw_command->redirs = redirs;
 
     return 0;
 }
@@ -273,92 +340,104 @@ static struct RawRedirection get_redirection(const struct Vm *vm,
     return raw_redir;
 }
 
-int run_command(struct Vm *vm, struct Expr *expr) {
-    if (!repl_mode)
-        remove_completed_jobs(vm);
-    struct Command *command = &expr->command;
+static void backup_fds(int *saved_in, int *saved_out, int *saved_err) {
+    *saved_in = dup(STDIN_FILENO);
+    if (*saved_in == -1) {
+        CASH_PERROR(EXIT_FAILURE, "dup", "could not duplicate stdin%s", "");
+        exit(EXIT_FAILURE);
+    }
+    *saved_out = dup(STDOUT_FILENO);
+    if (*saved_out == -1) {
+        CASH_PERROR(EXIT_FAILURE, "dup", "could not duplicate stdout%s", "");
+        exit(EXIT_FAILURE);
+    }
+    *saved_err = dup(STDERR_FILENO);
+    if (*saved_err == -1) {
+        CASH_PERROR(EXIT_FAILURE, "dup", "could not duplicate stderr%s", "");
+        exit(EXIT_FAILURE);
+    }
+}
 
-    struct RawCommand raw_command;
-    const int command_expansion = get_final_command(vm, command, &raw_command);
-    if (command_expansion != 0) {
-        free_raw_command(&raw_command);
-        return command_expansion;
+static void restore_fds(int saved_in, int saved_out, int saved_err) {
+    if (dup2(saved_in, STDIN_FILENO) == -1) {
+        CASH_PERROR(EXIT_FAILURE, "dup2", "could not restore stdin%s", "");
+        exit(EXIT_FAILURE);
+    }
+    if (dup2(saved_out, STDOUT_FILENO) == -1) {
+        CASH_PERROR(EXIT_FAILURE, "dup2", "could not restore stdout%s", "");
+        exit(EXIT_FAILURE);
+    }
+    if (dup2(saved_err, STDERR_FILENO) == -1) {
+        CASH_PERROR(EXIT_FAILURE, "dup2", "could not restore stderr%s", "");
+        exit(EXIT_FAILURE);
     }
 
-    if (raw_command.name == NULL) {
-        if (raw_command.redirs_count == 0) {
-            free_raw_command(&raw_command);
-            return vm->previous_exit_code;
+    close(saved_in);
+    close(saved_out);
+    close(saved_err);
+}
+
+int run_command(struct Vm *vm, struct Expr *expr, struct Job **jobp) {
+    if (!vm->repl_mode)
+        remove_completed_jobs(vm);
+
+    CASH_DEBUG(BLUE "running command ");
+    CASH_DEBUG_EXPR(print_expr(expr, 0));
+    CASH_DEBUG("\n");
+
+    struct Job *job = malloc(sizeof(struct Job));
+    CHECK_ALLOC(job);
+    make_job(vm, expr, job);
+    *jobp = job;
+    assert(job->first_process->next_process == NULL);
+    for (struct Process *process = job->first_process; process != NULL;
+         process = process->next_process) {
+        if (process->raw_command.is_subshell) {
+            CASH_DEBUG("subshell command: %s\n",
+                       process->raw_command.as_subshell.text);
         } else {
-            raw_command.name = strdup("/bin/true");
-            raw_command.args = malloc(2 * sizeof(char *));
-            CHECK_ALLOC(raw_command.args);
-            raw_command.args[0] = strdup("true");
-            raw_command.args[1] = NULL;
-            raw_command.args_count = 1;
+            CASH_DEBUG("command: %s\n", process->raw_command.as_cmd.name);
+            CASH_DEBUG("proc: %s\n", process->raw_command.as_cmd.name);
+            for (int i = 0; i < process->raw_command.as_cmd.args_count; ++i) {
+                CASH_DEBUG("\tArg %d: %s\n", i,
+                           process->raw_command.as_cmd.args[i]);
+            }
         }
     }
 
-    int builtin = is_builtin(raw_command.name);
+    struct RawCommand *raw_command = &job->first_process->raw_command;
+    int builtin =
+        raw_command->is_subshell ? -1 : is_builtin(raw_command->as_cmd.name);
+    CASH_DEBUG("builtin: %d\n", builtin);
+
     if (builtin != -1) {
-        int res = BUILTIN_FUNCS[builtin](vm, &raw_command);
-        free_raw_command(&raw_command);
-        return res;
+        int saved_in, saved_out, saved_err;
+        backup_fds(&saved_in, &saved_out, &saved_err);
+        setup_redirections(raw_command);
+        int res = BUILTIN_FUNCS[builtin](vm, raw_command);
+        restore_fds(saved_in, saved_out, saved_err);
+
+        vm->previous_exit_code = res % 0xFF;
+        return vm->previous_exit_code;
     }
-
-    if (strcmp(raw_command.args[0], "ls") == 0) {
-        char *color_arg = malloc((strlen("--color=auto") + 1) * sizeof(char));
-        CHECK_ALLOC(color_arg);
-        strcpy(color_arg, "--color=auto");
-
-        char **new_args = realloc(
-            raw_command.args, (raw_command.args_count + 2) * sizeof(char *));
-        CHECK_ALLOC(new_args);
-        new_args[raw_command.args_count] = color_arg;
-        new_args[raw_command.args_count + 1] = NULL;
-        raw_command.args_count++;
-        raw_command.args = new_args;
-    }
-
-    struct Process *process = malloc(sizeof(struct Process));
-    CHECK_ALLOC(process);
-    *process = (struct Process){
-        .next_process = NULL,
-        .raw_command = raw_command,
-        .completed = false,
-        .stopped = false,
-        .status = 0,
-        .pid = 0,
-    };
-    struct Job *job = malloc(sizeof(struct Job));
-    CHECK_ALLOC(job);
-    *job = (struct Job){
-        .next_job = NULL,
-        .first_process = process,
-        .command = strndup(expr->expr_text.string, expr->expr_text.length),
-        .notified = false,
-        .term_state = vm->shell_term_state,
-        .stderr = STDERR_FILENO,
-        .stdout = STDOUT_FILENO,
-        .stdin = STDIN_FILENO,
-        .pgid = 0};
 
     launch_job(vm, job, !expr->background);
 
-    vm->previous_exit_code = process->status % 0xFF;
+    CASH_DEBUG("oui\n");
+    if (!expr->background)
+        vm->previous_exit_code = job->first_process->status % 0xFF;
+    CASH_DEBUG("vm->previous_exit_code: %d\n", vm->previous_exit_code);
     return vm->previous_exit_code;
 }
 
-static int exec_expression(struct Vm *vm, struct Expr *expr) {
+static int exec_expression(struct Vm *vm, struct Expr *expr,
+                           struct Job **jobp) {
     switch (expr->type) {
         case EXPR_COMMAND:
-            return run_command(vm, expr);
-
-        case EXPR_SUBSHELL:
-            return run_subshell(vm, expr->subshell);
+            return run_command(vm, expr, jobp);
 
         case EXPR_NOT: {
-            if (exec_expression(vm, expr->binary.left) == 0) {
+            if (exec_expression(vm, expr->binary.left, jobp) == 0) {
                 vm->previous_exit_code = 1;
                 return 1;
             }
@@ -368,11 +447,11 @@ static int exec_expression(struct Vm *vm, struct Expr *expr) {
 
         case EXPR_AND:
         case EXPR_OR: {
-            const int left = exec_expression(vm, expr->binary.left);
+            const int left = exec_expression(vm, expr->binary.left, jobp);
             if ((left == 0 && expr->type == EXPR_AND) ||
                 (left != 0 && expr->type == EXPR_OR)) {
                 vm->previous_exit_code =
-                    exec_expression(vm, expr->binary.right);
+                    exec_expression(vm, expr->binary.right, jobp);
                 return vm->previous_exit_code;
             } else {
                 vm->previous_exit_code = left;
@@ -384,13 +463,16 @@ static int exec_expression(struct Vm *vm, struct Expr *expr) {
             struct Job *job = malloc(sizeof(struct Job));
             CHECK_ALLOC(job);
             int res = make_job(vm, expr, job);
+            *jobp = job;
             int i = 0;
             for (struct Process *process = job->first_process; process != NULL;
                  (process = process->next_process), ++i) {
                 struct RawCommand *raw_command = &process->raw_command;
-                CASH_DEBUG("Command %d:\n\tName: %s\n", i, raw_command->name);
-                for (int j = 0; j < raw_command->args_count; ++j) {
-                    CASH_DEBUG("\tArg %d: %s\n", j, raw_command->args[j]);
+                CASH_DEBUG("Command %d:\n\tName: %s\n", i,
+                           raw_command->as_cmd.name);
+                for (int j = 0; j < raw_command->as_cmd.args_count; ++j) {
+                    CASH_DEBUG("\tArg %d: %s\n", j,
+                               raw_command->as_cmd.args[j]);
                 }
             }
             CASH_DEBUG("res: %d\n", res);
@@ -415,22 +497,7 @@ static int exec_expression(struct Vm *vm, struct Expr *expr) {
     }
 }
 
-static int run_subshell(struct Vm *vm, struct Program *program) {
-    CASH_DEBUG(GREEN "Entering subshell\n" RESET);
-    const pid_t pid = fork();
-
-    if (pid == 0) {
-        int status = run_program(vm, program);
-        exit(status);
-    }
-
-    int status;
-    waitpid(pid, &status, 0);
-    CASH_DEBUG(GREEN "Exiting subshell\n" RESET);
-    return status;
-}
-
-static void make_process(struct Vm *vm, const struct Command *command,
+static void make_process(struct Vm *vm, struct Command *command,
                          struct Process *process) {
     struct RawCommand raw_command;
     get_final_command(vm, command, &raw_command);
@@ -445,33 +512,42 @@ static void make_process(struct Vm *vm, const struct Command *command,
     };
 }
 
-static int make_process_list(struct Vm *vm, const struct Expr *expr,
+static int make_process_list(struct Vm *vm, struct Expr *expr,
                              struct Process ***process_list) {
-    if (expr->binary.left->type == EXPR_PIPELINE) {
-        int res = make_process_list(vm, expr->binary.left, process_list);
-        if (res != 0)
-            return res;
-    } else {
-        assert(expr->binary.left->type == EXPR_COMMAND);
-        struct Process *new_process = malloc(sizeof(struct Process));
-        CHECK_ALLOC(new_process);
-        make_process(vm, &expr->binary.left->command, new_process);
-        **process_list = new_process;
-        *process_list = &new_process->next_process;
-    }
+    switch (expr->type) {
+        case EXPR_COMMAND: {
+            struct Process *new_process = malloc(sizeof(struct Process));
+            CHECK_ALLOC(new_process);
+            make_process(vm, &expr->command, new_process);
+            **process_list = new_process;
+            *process_list = &new_process->next_process;
+            return 0;
+        }
 
-    assert(expr->binary.right->type == EXPR_COMMAND);
-    struct Process *new_process = malloc(sizeof(struct Process));
-    CHECK_ALLOC(new_process);
-    make_process(vm, &expr->binary.right->command, new_process);
-    **process_list = new_process;
-    *process_list = &new_process->next_process;
-    return 0;
+        case EXPR_PIPELINE: {
+            int l = make_process_list(vm, expr->binary.left, process_list);
+            if (l != 0)
+                return l;
+            return make_process_list(vm, expr->binary.right, process_list);
+        }
+
+        default:
+            CASH_ERROR(EXIT_FAILURE,
+                       "(internal error) impossible expression type to "
+                       "make_process_list%s",
+                       "");
+            exit(EXIT_FAILURE);
+    }
 }
 
-static int make_job(struct Vm *vm, const struct Expr *expr, struct Job *jobp) {
+static int make_job(struct Vm *vm, struct Expr *expr, struct Job *jobp) {
+    CASH_DEBUG(RED "expr: ");
+    CASH_DEBUG_EXPR(print_expr(expr, 0));
+    CASH_DEBUG(RESET "\n has   expr_text: %.*s\n", expr->expr_text.length,
+               expr->expr_text.string);
     struct Job job = {
         .first_process = NULL,
+        .next_job = NULL,
         .command = strndup(expr->expr_text.string, expr->expr_text.length),
         .pgid = 0,
         .notified = false,
@@ -604,21 +680,21 @@ static void update_prompt(struct Vm *vm) {
 }
 
 static int change_dir(struct Vm *vm, const struct RawCommand *command) {
-    if (command->args_count > 2) {
+    if (command->as_cmd.args_count > 2) {
         CASH_ERROR(EXIT_FAILURE,
                    "cd: too many arguments (one expected, got %d)\n",
-                   command->args_count - 1);
+                   command->as_cmd.args_count - 1);
         return EXIT_FAILURE;
     }
     int result = 0;
 
     char *old_pwd = vm->old_pwd;
     vm->old_pwd = vm->pwd;
-    if (command->args_count == 1) {
+    if (command->as_cmd.args_count == 1) {
         result = chdir(vm->userpw->pw_dir);
         vm->pwd = strdup(vm->userpw->pw_dir);
     } else {
-        const char *arg = command->args[1];
+        const char *arg = command->as_cmd.args[1];
         if (strcmp(arg, "-") == 0) {
             result = chdir(old_pwd);
             vm->pwd = old_pwd;
@@ -643,7 +719,7 @@ static int change_dir(struct Vm *vm, const struct RawCommand *command) {
 
     if (result == -1) {
         CASH_PERROR(EXIT_FAILURE, "cd", "%s", "");
-        return 255;
+        return EXIT_FAILURE;
     }
 
     update_prompt(vm);
@@ -651,21 +727,21 @@ static int change_dir(struct Vm *vm, const struct RawCommand *command) {
 }
 
 static int exit_shell(struct Vm *vm, const struct RawCommand *raw_command) {
-    if (raw_command->args_count > 2) {
+    if (raw_command->as_cmd.args_count > 2) {
         CASH_ERROR(EXIT_FAILURE,
                    "exit: too many arguments (one expected, got %d)\n",
-                   raw_command->args_count - 1);
+                   raw_command->as_cmd.args_count - 1);
         return EXIT_FAILURE;
     }
 
-    if (raw_command->args_count == 1) {
+    if (raw_command->as_cmd.args_count == 1) {
         vm->previous_exit_code = 0;
     } else {
         char *endptr;
-        long exit_code = strtol(raw_command->args[1], &endptr, 10);
+        long exit_code = strtol(raw_command->as_cmd.args[1], &endptr, 10);
         if (*endptr != '\0' || exit_code < 0 || exit_code > 255) {
             CASH_ERROR(EXIT_FAILURE, "exit: invalid exit code `%s`\n",
-                       raw_command->args[1]);
+                       raw_command->as_cmd.args[1]);
             return EXIT_FAILURE;
         }
         vm->previous_exit_code = (int)exit_code;


### PR DESCRIPTION
### Subshell Support:

* Added a new `Program` structure to represent subshells, including methods for initialization and cleanup (`include/cash/ast.h`, `[[1]](diffhunk://#diff-5c73345f47bc155c0619a164b2ffad36fc54ffdb315c90a018262f09ef590eaaR7-R16)`, `[[2]](diffhunk://#diff-5c73345f47bc155c0619a164b2ffad36fc54ffdb315c90a018262f09ef590eaaL72-R94)`).
* Updated `Command` and `RawCommand` structures to support subshells using a union for either a command or a subshell, along with an `is_subshell` flag (`include/cash/ast.h`, `[[1]](diffhunk://#diff-5c73345f47bc155c0619a164b2ffad36fc54ffdb315c90a018262f09ef590eaaL34-L43)`; `include/cash/job_control.h`, `[[2]](diffhunk://#diff-e5bf448aca7826695734513ba5fc96a884091a6879c5d8372a2f3120d13b3396R20-R30)`).
* Modified the `launch_process` and `launch_job` functions to handle subshell execution by creating a new `Vm` instance for subshells (`src/job_control.c`, `[[1]](diffhunk://#diff-d1902cc224198eeb806485a883e70a1adcdaff36bfbb112bdcd4e22646900ec6R174-R209)`, `[[2]](diffhunk://#diff-d1902cc224198eeb806485a883e70a1adcdaff36bfbb112bdcd4e22646900ec6R226-R260)`).

### Code Refactoring:

* Removed the `EXPR_SUBSHELL` expression type and replaced it with the new subshell handling approach (`include/cash/ast.h`, `[include/cash/ast.hL57](diffhunk://#diff-5c73345f47bc155c0619a164b2ffad36fc54ffdb315c90a018262f09ef590eaaL57)`).
* Updated the `print_command` and `print_expr` functions to handle the new subshell representation (`src/ast.c`, `[[1]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL133-L138)`, `[[2]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL171-R181)`).

### Debugging Enhancements:

* Introduced `CASH_DEBUG` and `CASH_DEBUG_EXPR` macros to enable selective debug output for specific files, controlled by a `debug_files` array (`include/cash/util.h`, `[include/cash/util.hL8-R37](diffhunk://#diff-523dc377fe2a69990fa8a7d9f02738c5e2132027cbd50818906f7fe6ed746f10L8-R37)`).
* Added detailed debug messages in job control functions to trace process and job management (`src/job_control.c`, `[[1]](diffhunk://#diff-d1902cc224198eeb806485a883e70a1adcdaff36bfbb112bdcd4e22646900ec6R174-R209)`, `[[2]](diffhunk://#diff-d1902cc224198eeb806485a883e70a1adcdaff36bfbb112bdcd4e22646900ec6L291-R360)`).

### Miscellaneous Updates:

* Renamed the `repl_mode` variable to `is_repl_mode` for clarity and consistency across the codebase (`include/cash/error.h`, `[[1]](diffhunk://#diff-9fa1e9b418d47a6fe8486928ec70f0b5356162ef4aee01639af136545e34a3ffL12-R20)`; `src/ast.c`, `[[2]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL25-R25)`).
* Updated the `Vm` structure and its initialization to include new fields for subshell and background execution (`include/cash/vm.h`, `[[1]](diffhunk://#diff-c7cff55c12dbe2f0d6f4a5a1c9d3909811cf0666a3f4be74716c393102a7a165R30-R31)`, `[[2]](diffhunk://#diff-c7cff55c12dbe2f0d6f4a5a1c9d3909811cf0666a3f4be74716c393102a7a165L38-R40)`).

These changes collectively enhance the shell's functionality, particularly in handling subshells, while making the code easier to debug and maintain.