### PR TITLE
Command substitution

### DIFF
--- a/include/cash/ast.h
+++ b/include/cash/ast.h
@@ -92,7 +92,7 @@ void print_program(const struct Program* program, int indent);
 void print_statement(const struct Stmt* stmt, int indent);
 void print_expr(const struct Expr* expr, int indent);
 void print_command(const struct Command* command, int indent);
-void print_redirection(const struct Redirection* redirection);
+void print_redirection(const struct Redirection* redirection, int indent);
 #endif
 
 #endif  // CASH_AST_H

--- a/include/cash/parser/parser.h
+++ b/include/cash/parser/parser.h
@@ -8,15 +8,18 @@
 struct Parser {
     struct Lexer* lexer;
     struct Token current_token;
-    struct Token next_token;
 
     const char* input;
     struct Program program;
     bool error;
     bool is_subparser;
+    bool is_command_sub_parser;
 };
 
 struct Parser parser_new(const char* input, bool repl_mode);
+struct Parser subparser_from_lexer(struct Lexer* lexer);
+struct Parser make_subparser(const struct Parser* parser);
+bool parse_subshell(struct Parser* parser, struct Program* program);
 void reset_parser(const char* input, struct Parser* parser);
 void free_parser(const struct Parser* parser);
 

--- a/include/cash/string.h
+++ b/include/cash/string.h
@@ -1,6 +1,8 @@
 #ifndef CASH_STRING_H
 #define CASH_STRING_H
 
+#include <stdbool.h>
+
 struct Program;
 
 enum StringComponentType {
@@ -46,21 +48,28 @@ struct ShellString make_string(void);
 void add_string_literal(struct ShellString* str, enum StringComponentType type,
                         const char* literal, int length, int escapes);
 void add_string_component(struct ShellString* str,
-                          enum StringComponentType type, const char* value,
-                          int length);
+                          struct StringComponent component);
+void add_string_component_from_value(struct ShellString* str,
+                                     enum StringComponentType type,
+                                     const char* value, int length);
+void add_command_substitution(struct ShellString* str, struct Program* program);
 
 char* grow_string(char* str, int new_size);
 void append(struct String* string, const char* value);
 void append_n(struct String* string, const char* value, int length);
 void append_n_terminate(struct String* string, const char* value, int length);
 
+bool is_null_string(struct ShellString* str);
+struct String strip(const struct String* string);
+
 void free_string_component(const struct StringComponent* component);
 void free_shell_string(const struct ShellString* str);
 void free_string(const struct String* string);
 
 #ifndef NDEBUG
-void print_string(const struct ShellString* string);
-void print_string_component(const struct StringComponent* component);
+void print_string(const struct ShellString* string, int indent);
+void print_string_component(const struct StringComponent* component,
+                            int indent);
 #endif
 
 #endif  // CASH_STRING_H

--- a/include/cash/string.h
+++ b/include/cash/string.h
@@ -24,6 +24,8 @@ struct StringComponent {
         struct Program* command_substitution;
     };
 
+    bool quoted;  // used for example when a variable substitution is inside a
+                  // double-quoted string
     int escapes;
     int length;
 };
@@ -51,8 +53,10 @@ void add_string_component(struct ShellString* str,
                           struct StringComponent component);
 void add_string_component_from_value(struct ShellString* str,
                                      enum StringComponentType type,
-                                     const char* value, int length);
-void add_command_substitution(struct ShellString* str, struct Program* program);
+                                     const char* value, int length,
+                                     bool quoted);
+void add_command_substitution(struct ShellString* str, struct Program* program,
+                              bool quoted);
 
 char* grow_string(char* str, int new_size);
 void append(struct String* string, const char* value);
@@ -60,7 +64,7 @@ void append_n(struct String* string, const char* value, int length);
 void append_n_terminate(struct String* string, const char* value, int length);
 
 bool is_null_string(struct ShellString* str);
-struct String strip(const struct String* string);
+struct String strip_end(const struct String* string);
 
 void free_string_component(const struct StringComponent* component);
 void free_shell_string(const struct ShellString* str);

--- a/include/cash/util.h
+++ b/include/cash/util.h
@@ -6,29 +6,29 @@
 
 #ifndef NDEBUG
 
-static const char* debug_files[] = {"repl.c", "parser.c", "lexer.c"};
+static const char* debug_files[] = {"repl.c", "parser.c", "lexer.c", "vm.c"};
 static const int debug_files_len = sizeof(debug_files) / sizeof(debug_files[0]);
 
-#define CASH_DEBUG(...)                                       \
-    do {                                                      \
-        for (int i = 0; i < debug_files_len; ++i) {           \
-            if (debug_files[i][0] == '*' ||                   \
-                strcmp(__FILE_NAME__, debug_files[i]) == 0) { \
-                fprintf(stderr, __VA_ARGS__);                 \
-                break;                                        \
-            }                                                 \
-        }                                                     \
+#define CASH_DEBUG(...)                                            \
+    do {                                                           \
+        for (int _____i = 0; _____i < debug_files_len; ++_____i) { \
+            if (debug_files[_____i][0] == '*' ||                   \
+                strcmp(__FILE_NAME__, debug_files[_____i]) == 0) { \
+                fprintf(stderr, __VA_ARGS__);                      \
+                break;                                             \
+            }                                                      \
+        }                                                          \
     } while (0)
 
-#define CASH_DEBUG_EXPR(expr)                                 \
-    do {                                                      \
-        for (int i = 0; i < debug_files_len; ++i) {           \
-            if (debug_files[i][0] == '*' ||                   \
-                strcmp(__FILE_NAME__, debug_files[i]) == 0) { \
-                (expr);                                       \
-                break;                                        \
-            }                                                 \
-        }                                                     \
+#define CASH_DEBUG_EXPR(expr)                                     \
+    do {                                                          \
+        for (int ____i = 0; ____i < debug_files_len; ++____i) {   \
+            if (debug_files[____i][0] == '*' ||                   \
+                strcmp(__FILE_NAME__, debug_files[____i]) == 0) { \
+                (expr);                                           \
+                break;                                            \
+            }                                                     \
+        }                                                         \
     } while (0)
 #else
 #define CASH_DEBUG(...) ((void)0)

--- a/include/cash/util.h
+++ b/include/cash/util.h
@@ -6,7 +6,7 @@
 
 #ifndef NDEBUG
 
-static const char* debug_files[] = {"repl.c", "parser.c"};
+static const char* debug_files[] = {"repl.c", "parser.c", "lexer.c"};
 static const int debug_files_len = sizeof(debug_files) / sizeof(debug_files[0]);
 
 #define CASH_DEBUG(...)                                       \
@@ -37,7 +37,7 @@ static const int debug_files_len = sizeof(debug_files) / sizeof(debug_files[0]);
     } while (0)
 #endif
 
-char* read_all_stdin(void);
+struct String read_all_fd(int fd);
 char* read_file(const char* path);
 
 void run_string(const char* text, int argc, char** argv);

--- a/src/ast.c
+++ b/src/ast.c
@@ -90,6 +90,7 @@ void free_program(const struct Program *program) {
 #ifndef NDEBUG
 void print_string_component(const struct StringComponent *component,
                             int indent) {
+    const char *quote = component->quoted ? BOLD BLUE "\"" RESET : "";
     switch (component->type) {
         case STRING_COMPONENT_LITERAL:
             fprintf(stderr, MAGENTA "%s" RESET, component->literal);
@@ -101,15 +102,17 @@ void print_string_component(const struct StringComponent *component,
             fprintf(stderr, BOLD CYAN "'%s'" RESET, component->literal);
             break;
         case STRING_COMPONENT_VAR_SUB:
-            fprintf(stderr, GREEN "$%s" RESET, component->var_substitution);
+            fprintf(stderr, "%s" GREEN "$%s" RESET "%s", quote,
+                    component->var_substitution, quote);
             break;
         case STRING_COMPONENT_BRACED_SUB:
-            fprintf(stderr, GREEN "$%s" RESET, component->braced_substitution);
+            fprintf(stderr, "%s" GREEN "$%s" RESET "%s", quote,
+                    component->braced_substitution, quote);
             break;
         case STRING_COMPONENT_COMMAND_SUBSTITUTION:
-            fprintf(stderr, GREEN "$(" RESET);
+            fprintf(stderr, "%s" GREEN "$(" RESET, quote);
             print_program(component->command_substitution, indent + 1);
-            fprintf(stderr, GREEN ")" RESET);
+            fprintf(stderr, GREEN ")" RESET "%s", quote);
             break;
     }
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -88,7 +88,8 @@ void free_program(const struct Program *program) {
 }
 
 #ifndef NDEBUG
-void print_string_component(const struct StringComponent *component) {
+void print_string_component(const struct StringComponent *component,
+                            int indent) {
     switch (component->type) {
         case STRING_COMPONENT_LITERAL:
             fprintf(stderr, MAGENTA "%s" RESET, component->literal);
@@ -106,14 +107,16 @@ void print_string_component(const struct StringComponent *component) {
             fprintf(stderr, GREEN "$%s" RESET, component->braced_substitution);
             break;
         case STRING_COMPONENT_COMMAND_SUBSTITUTION:
-            fprintf(stderr, "command sub");
+            fprintf(stderr, GREEN "$(" RESET);
+            print_program(component->command_substitution, indent + 1);
+            fprintf(stderr, GREEN ")" RESET);
             break;
     }
 }
 
-void print_string(const struct ShellString *string) {
+void print_string(const struct ShellString *string, int indent) {
     for (int i = 0; i < string->component_count; ++i)
-        print_string_component(&string->components[i]);
+        print_string_component(&string->components[i], indent);
 }
 
 void print_program(const struct Program *program, int indent) {
@@ -170,24 +173,24 @@ void print_command(const struct Command *command, int indent) {
     } else {
         fprintf(stderr, "Command(<args: %d> " BOLD CYAN,
                 command->as_cmd.arguments.argument_count);
-        print_string(&command->as_cmd.command_name);
+        print_string(&command->as_cmd.command_name, indent + 1);
         fprintf(stderr, "%s" RESET,
                 command->as_cmd.arguments.argument_count ? " " : "");
 
         for (int i = 0; i < command->as_cmd.arguments.argument_count; ++i) {
-            print_string(&command->as_cmd.arguments.arguments[i]);
+            print_string(&command->as_cmd.arguments.arguments[i], indent + 1);
             fprintf(stderr, " ");
         }
     }
 
     for (int i = 0; i < command->redirection_count; ++i) {
-        print_redirection(&command->redirections[i]);
+        print_redirection(&command->redirections[i], indent + 1);
         fprintf(stderr, " ");
     }
     fprintf(stderr, ")");
 }
 
-void print_redirection(const struct Redirection *redirection) {
+void print_redirection(const struct Redirection *redirection, int indent) {
     fprintf(stderr, "( ");
     if (redirection->left != -1) {
         fprintf(stderr, CYAN "%d" RESET, redirection->left);
@@ -221,7 +224,7 @@ void print_redirection(const struct Redirection *redirection) {
         fprintf(stderr, CYAN "%d" RESET, redirection->right);
     } else {
         fprintf(stderr, " ");
-        print_string(&redirection->file_name);
+        print_string(&redirection->file_name, indent);
     }
     fprintf(stderr, " )");
 }

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ int main(const int argc, char* argv[]) {
     // return 0;
     if (argc == 1) {
         if (!isatty(STDIN_FILENO)) {
-            char* input = read_all_stdin();
+            char* input = read_all_fd(STDIN_FILENO).string;
             run_string(input, 0, argv);
             free(input);
         } else {

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <cash/error.h>
 #include <cash/parser/lexer.h>
+#include <cash/parser/parser.h>
 #include <cash/parser/token.h>
 #include <ctype.h>
 #include <limits.h>
@@ -10,6 +11,7 @@
 
 #include "cash/ast.h"
 #include "cash/memory.h"
+#include "cash/string.h"
 
 extern bool is_repl_mode;
 
@@ -34,11 +36,12 @@ static void consume_sq_string(struct Lexer* lexer);
 static void consume_dq_string(struct Lexer* lexer);
 static void consume_unquoted_string(struct Lexer* lexer);
 static void consume_substitution(struct Lexer* lexer);
+static void consume_command_substitution(struct Lexer* lexer);
 
 static struct Token lexer_lex(struct Lexer* lexer);
 
 static void lexer_push_token(struct Lexer* lexer, struct Token token);
-static struct Token lexer_pop_token(struct Lexer* lexer);
+// static struct Token lexer_pop_token(struct Lexer* lexer);
 static void lexer_reset_queue(struct Lexer* lexer);
 
 static const bool kPunctuation[128] = {
@@ -91,12 +94,6 @@ void free_lexer(const struct Lexer* lexer) {
 }
 
 struct Token lexer_next_token(struct Lexer* lexer) {
-    if (lexer->repl_mode) {
-        if (lexer->token_queue_size == 0)
-            return make_eof(lexer);
-        const struct Token token = lexer_pop_token(lexer);
-        return token;
-    }
     return lexer_lex(lexer);
 }
 
@@ -388,6 +385,13 @@ static struct Token consume_string(struct Lexer* lexer) {
             break;
     }
     lexer->last_column += lexer->position - lexer->token_start;
+
+    if (lexer->current_string.component_count == 0) {
+        struct StringComponent empty_component = {
+            .type = STRING_COMPONENT_DQ, .literal = strdup(""), .length = 0};
+        add_string_component(&lexer->current_string, empty_component);
+    }
+
     struct Token token = make_token(TOKEN_WORD, lexer);
     token.value.word = lexer->current_string;
     lexer->continue_string = false;
@@ -470,9 +474,15 @@ static void consume_sq_string(struct Lexer* lexer) {
 static void consume_substitution(struct Lexer* lexer) {
     advance(lexer);  // '$'
 
+    if (peek(lexer) == '(') {
+        consume_command_substitution(lexer);
+        return;
+    }
+
     if (peek(lexer) == '?' || peek(lexer) == '#') {
-        add_string_component(&lexer->current_string, STRING_COMPONENT_VAR_SUB,
-                             peek(lexer) == '?' ? "?" : "#", 1);
+        add_string_component_from_value(&lexer->current_string,
+                                        STRING_COMPONENT_VAR_SUB,
+                                        peek(lexer) == '?' ? "?" : "#", 1);
         advance(lexer);
         return;
     }
@@ -487,9 +497,36 @@ static void consume_substitution(struct Lexer* lexer) {
     }
 
     if (lexer->position - name_start != 0)
-        add_string_component(&lexer->current_string, STRING_COMPONENT_VAR_SUB,
-                             &lexer->input[name_start],
-                             lexer->position - name_start);
+        add_string_component_from_value(
+            &lexer->current_string, STRING_COMPONENT_VAR_SUB,
+            &lexer->input[name_start], lexer->position - name_start);
+}
+
+static void consume_command_substitution(struct Lexer* lexer) {
+    struct Parser pseudo_parser = subparser_from_lexer(lexer);
+    struct Program* program = malloc(sizeof(struct Program));
+    if (!program) {
+        CASH_ERROR(EXIT_FAILURE, "Memory allocation failed%s\n", "");
+        lexer->error = true;
+        return;
+    }
+
+    struct ShellString current_string = lexer->current_string;
+    bool continue_string = lexer->continue_string;
+    bool substitution_in_quotes = lexer->substitution_in_quotes;
+
+    lexer->current_string = make_string();
+    lexer->continue_string = false;
+    lexer->substitution_in_quotes = false;
+    if (!parse_subshell(&pseudo_parser, program)) {
+        lexer->error = true;
+        return;
+    }
+    add_command_substitution(&current_string, program);
+    lexer->token_start++;  // skip the ')'
+    lexer->current_string = current_string;
+    lexer->continue_string = continue_string;
+    lexer->substitution_in_quotes = substitution_in_quotes;
 }
 
 static void lexer_push_token(struct Lexer* lexer, struct Token token) {
@@ -497,12 +534,12 @@ static void lexer_push_token(struct Lexer* lexer, struct Token token) {
              struct Token);
 }
 
-static struct Token lexer_pop_token(struct Lexer* lexer) {
-    const struct Token token = lexer->token_queue[lexer->token_queue_head];
-    lexer->token_queue_head++;
-    lexer->token_queue_size--;
-    return token;
-}
+// static struct Token lexer_pop_token(struct Lexer* lexer) {
+//     const struct Token token = lexer->token_queue[lexer->token_queue_head];
+//     lexer->token_queue_head++;
+//     lexer->token_queue_size--;
+//     return token;
+// }
 
 static void lexer_reset_queue(struct Lexer* lexer) {
     lexer->token_queue_head = 0;

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -480,9 +480,9 @@ static void consume_substitution(struct Lexer* lexer) {
     }
 
     if (peek(lexer) == '?' || peek(lexer) == '#') {
-        add_string_component_from_value(&lexer->current_string,
-                                        STRING_COMPONENT_VAR_SUB,
-                                        peek(lexer) == '?' ? "?" : "#", 1);
+        add_string_component_from_value(
+            &lexer->current_string, STRING_COMPONENT_VAR_SUB,
+            peek(lexer) == '?' ? "?" : "#", 1, lexer->substitution_in_quotes);
         advance(lexer);
         return;
     }
@@ -499,7 +499,8 @@ static void consume_substitution(struct Lexer* lexer) {
     if (lexer->position - name_start != 0)
         add_string_component_from_value(
             &lexer->current_string, STRING_COMPONENT_VAR_SUB,
-            &lexer->input[name_start], lexer->position - name_start);
+            &lexer->input[name_start], lexer->position - name_start,
+            lexer->substitution_in_quotes);
 }
 
 static void consume_command_substitution(struct Lexer* lexer) {
@@ -522,7 +523,7 @@ static void consume_command_substitution(struct Lexer* lexer) {
         lexer->error = true;
         return;
     }
-    add_command_substitution(&current_string, program);
+    add_command_substitution(&current_string, program, substitution_in_quotes);
     lexer->token_start++;  // skip the ')'
     lexer->current_string = current_string;
     lexer->continue_string = continue_string;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -9,6 +9,7 @@
 #include "cash/ast.h"
 #include "cash/error.h"
 #include "cash/memory.h"
+#include "cash/string.h"
 #include "cash/util.h"
 
 #define ALLOC_CHECKED(ptr, size)                                          \
@@ -30,8 +31,6 @@
 
 extern bool is_repl_mode;
 
-static struct Parser make_subparser(const struct Parser* parser);
-
 static bool is_at_end(const struct Parser* parser);
 static struct Token peek(const struct Parser* parser);
 static enum TokenType peek_tt(const struct Parser* parser);
@@ -40,7 +39,6 @@ static struct Token advance(struct Parser* parser);
 static bool match(struct Parser* parser, enum TokenType type);
 static struct Token consume(enum TokenType type, struct Parser* parser);
 
-static bool parse_subshell(struct Parser* parser, struct Program* program);
 static bool parse_terminal(struct Parser* parser, struct Expr* expr);
 static bool parse_not_expr(struct Parser* parser, struct Expr* expr);
 static bool parse_pipeline(struct Parser* parser, struct Expr* expr);
@@ -57,7 +55,22 @@ struct Parser parser_new(const char* input, bool repl_mode) {
                                   .input = input,
                                   .program = make_program(),
                                   .error = false,
-                                  .is_subparser = false};
+                                  .is_subparser = false,
+                                  .is_command_sub_parser = false};
+    return parser;
+}
+
+// used for command substitutions only
+// if this ever changes, .is_command_sub_parser should be set to false and then
+// manually set when parsing a command substitution
+struct Parser subparser_from_lexer(struct Lexer* lexer) {
+    struct Parser parser = {.lexer = lexer,
+                            .input = lexer->input,
+                            .program = make_program(),
+                            .error = false,
+                            .is_subparser = true,
+                            .is_command_sub_parser = true};
+    parser.current_token = lexer_next_token(lexer);
     return parser;
 }
 
@@ -76,7 +89,6 @@ void free_parser(const struct Parser* parser) {
 bool parse_program(struct Parser* parser) {
     if (!parser->is_subparser) {
         parser->current_token = lexer_next_token(parser->lexer);
-        parser->next_token = lexer_next_token(parser->lexer);
     }
     while (peek_tt(parser) != TOKEN_EOF) {
         if (parser->error) {
@@ -96,7 +108,7 @@ bool parse_program(struct Parser* parser) {
     return true;
 }
 
-static struct Parser make_subparser(const struct Parser* parser) {
+struct Parser make_subparser(const struct Parser* parser) {
     struct Parser subparser = *parser;
     subparser.is_subparser = true;
     subparser.program = make_program();
@@ -251,7 +263,7 @@ static bool parse_terminal(struct Parser* parser, struct Expr* expr) {
     return parse_command(parser, expr);
 }
 
-static bool parse_subshell(struct Parser* parser, struct Program* program) {
+bool parse_subshell(struct Parser* parser, struct Program* program) {
     const char* begin = advance(parser).lexeme;
     struct Parser subparser = make_subparser(parser);
 
@@ -261,9 +273,24 @@ static bool parse_subshell(struct Parser* parser, struct Program* program) {
     }
 
     parser->current_token = subparser.current_token;
-    parser->next_token = subparser.next_token;
 
-    const struct Token rparen = consume(TOKEN_RPAREN, parser);
+    struct Token rparen;
+    if (parser->is_command_sub_parser) {
+        // do not consume, it will cause problems with a quoted command
+        // substitution for example, "echo $(echo 'hello world') abcd" after ')'
+        // is parsed, consume will "advance" and ask for the next token next
+        // token will see a single '"' and error out, it has no way to know that
+        // there wasd a quote before
+        rparen = peek(parser);
+        if (rparen.type != TOKEN_RPAREN) {
+            CASH_ERROR(EXIT_FAILURE, "Expected `)`, found `%s`\n",
+                       token_type_to_string(rparen.type));
+            parser->error = true;
+            return false;
+        }
+    } else {
+        rparen = consume(TOKEN_RPAREN, parser);
+    }
     const char* end = rparen.lexeme + rparen.lexeme_length;
 
     if (parser->error)
@@ -308,7 +335,7 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
         switch (next.type) {
             case TOKEN_WORD: {
                 if (command.is_subshell) {
-                    CASH_ERROR(EXIT_FAILURE, "unexpected token `%.*s`",
+                    CASH_ERROR(EXIT_FAILURE, "unexpected token `%.*s`\n",
                                next.lexeme_length, next.lexeme);
                     parser->error = true;
                     return false;
@@ -318,6 +345,9 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
                     command.as_cmd.command_name = advance(parser).value.word;
                 } else {
                     const struct Token argument = advance(parser);
+                    CASH_DEBUG("adding argument ");
+                    CASH_DEBUG_EXPR(print_string(&argument.value.word, 0));
+                    CASH_DEBUG("\n");
                     add_argument(&command.as_cmd.arguments,
                                  argument.value.word);
                 }
@@ -327,6 +357,12 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
             case TOKEN_RPAREN:
                 if (parser->is_subparser)
                     break_out = true;
+                else {
+                    CASH_ERROR(EXIT_FAILURE, "unexpected token `%.*s`\n",
+                               next.lexeme_length, next.lexeme);
+                    parser->error = true;
+                    return false;
+                }
                 continue;
 
             case TOKEN_PIPE:
@@ -346,9 +382,10 @@ static bool parse_command(struct Parser* parser, struct Expr* expr) {
                 parser->error = true;
                 return false;
             default:
-                CASH_ERROR(EXIT_FAILURE, "unexpected token `%.*s`",
+                CASH_ERROR(EXIT_FAILURE, "unexpected token `%.*s`\n",
                            next.lexeme_length, next.lexeme);
-                exit(EXIT_FAILURE);
+                parser->error = true;
+                return false;
         }
     }
 
@@ -430,8 +467,7 @@ static struct Token advance(struct Parser* parser) {
     if (parser->current_token.type == TOKEN_ERROR)
         parser->error = true;
     if (!is_at_end(parser)) {
-        parser->current_token = parser->next_token;
-        parser->next_token = lexer_next_token(parser->lexer);
+        parser->current_token = lexer_next_token(parser->lexer);
     }
 
 #ifndef NDEBUG

--- a/src/repl.c
+++ b/src/repl.c
@@ -28,7 +28,6 @@ void run_repl(struct Repl* repl) {
         }
 
         reset_parser(repl->line, &repl->parser);
-        lexer_lex_full(repl->parser.lexer);
 
         const bool success = parse_program(&repl->parser);
         if (repl->parser.error) {

--- a/src/string.c
+++ b/src/string.c
@@ -2,18 +2,15 @@
 #include <cash/error.h>
 #include <cash/memory.h>
 #include <cash/string.h>
+#include <ctype.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-extern bool is_repl_mode;
+#include "cash/ast.h"
 
-static void add_component(struct ShellString *str,
-                          struct StringComponent comp) {
-    ADD_LIST(str, component_count, component_capacity, components, comp,
-             struct StringComponent);
-}
+extern bool is_repl_mode;
 
 struct ShellString make_string(void) {
     return (struct ShellString){
@@ -24,20 +21,31 @@ void add_string_literal(struct ShellString *str, enum StringComponentType type,
                         const char *literal, int length, int escapes) {
     assert(type == STRING_COMPONENT_LITERAL || type == STRING_COMPONENT_DQ ||
            type == STRING_COMPONENT_SQ);
-    add_component(str,
-                  (struct StringComponent){.literal = strndup(literal, length),
-                                           .type = type,
-                                           .length = length,
-                                           .escapes = escapes});
+    if (length > 0) {
+        add_string_component(
+            str, (struct StringComponent){.literal = strndup(literal, length),
+                                          .type = type,
+                                          .length = length,
+                                          .escapes = escapes});
+    }
 }
 
 void add_string_component(struct ShellString *str,
-                          enum StringComponentType type, const char *value,
-                          int length) {
+                          struct StringComponent comp) {
+    ADD_LIST(str, component_count, component_capacity, components, comp,
+             struct StringComponent);
+}
+
+void add_string_component_from_value(struct ShellString *str,
+                                     enum StringComponentType type,
+                                     const char *value, int length) {
     assert(type == STRING_COMPONENT_BRACED_SUB ||
            type == STRING_COMPONENT_VAR_SUB ||
            type == STRING_COMPONENT_COMMAND_SUBSTITUTION);
     char *val = strndup(value, length);
+
+    if (length <= 0)
+        return;
 
     struct StringComponent component;
     switch (type) {
@@ -66,7 +74,16 @@ void add_string_component(struct ShellString *str,
         }
     }
 
-    add_component(str, component);
+    add_string_component(str, component);
+}
+
+void add_command_substitution(struct ShellString *str,
+                              struct Program *program) {
+    assert(program != NULL);
+    add_string_component(str, (struct StringComponent){
+                                  .type = STRING_COMPONENT_COMMAND_SUBSTITUTION,
+                                  .length = 0,
+                                  .command_substitution = program});
 }
 
 void free_string_component(const struct StringComponent *component) {
@@ -83,7 +100,9 @@ void free_string_component(const struct StringComponent *component) {
             free(component->literal);
             break;
         case STRING_COMPONENT_COMMAND_SUBSTITUTION:
-            assert(false);
+            free_program(component->command_substitution);
+            free(component->command_substitution);
+            break;
     }
 }
 
@@ -120,4 +139,29 @@ void append_n(struct String *string, const char *value, int length) {
 void append_n_terminate(struct String *string, const char *value, int length) {
     append_n(string, value, length + 1);
     string->string[string->length] = '\0';
+}
+
+bool is_null_string(struct ShellString *str) {
+    return str->component_count == 0 ||
+           (str->component_count == 1 && str->components[0].length == 0 &&
+            str->components[0].type != STRING_COMPONENT_COMMAND_SUBSTITUTION);
+}
+
+struct String strip(const struct String *string) {
+    int length = string->length;
+    int start = 0;
+
+    while (start < string->length && isspace(string->string[start])) {
+        start++;
+        length--;
+    }
+
+    int end = string->length - 1;
+    while (end >= start && isspace(string->string[end])) {
+        end--;
+        length--;
+    }
+
+    return (struct String){.string = strndup(&string->string[start], length),
+                           .length = length};
 }

--- a/src/string.c
+++ b/src/string.c
@@ -22,11 +22,13 @@ void add_string_literal(struct ShellString *str, enum StringComponentType type,
     assert(type == STRING_COMPONENT_LITERAL || type == STRING_COMPONENT_DQ ||
            type == STRING_COMPONENT_SQ);
     if (length > 0) {
-        add_string_component(
-            str, (struct StringComponent){.literal = strndup(literal, length),
-                                          .type = type,
-                                          .length = length,
-                                          .escapes = escapes});
+        add_string_component(str, (struct StringComponent){
+                                      .literal = strndup(literal, length),
+                                      .type = type,
+                                      .length = length,
+                                      .quoted = type == STRING_COMPONENT_DQ ||
+                                                type == STRING_COMPONENT_SQ,
+                                      .escapes = escapes});
     }
 }
 
@@ -38,10 +40,10 @@ void add_string_component(struct ShellString *str,
 
 void add_string_component_from_value(struct ShellString *str,
                                      enum StringComponentType type,
-                                     const char *value, int length) {
+                                     const char *value, int length,
+                                     bool quoted) {
     assert(type == STRING_COMPONENT_BRACED_SUB ||
-           type == STRING_COMPONENT_VAR_SUB ||
-           type == STRING_COMPONENT_COMMAND_SUBSTITUTION);
+           type == STRING_COMPONENT_VAR_SUB);
     char *val = strndup(value, length);
 
     if (length <= 0)
@@ -54,6 +56,7 @@ void add_string_component_from_value(struct ShellString *str,
                 .type = type,
                 .length = length,
                 .braced_substitution = val,
+                .quoted = quoted,
             };
             break;
         }
@@ -62,6 +65,7 @@ void add_string_component_from_value(struct ShellString *str,
                 .type = type,
                 .length = length,
                 .var_substitution = val,
+                .quoted = quoted,
             };
             break;
         }
@@ -69,7 +73,8 @@ void add_string_component_from_value(struct ShellString *str,
             component = (struct StringComponent){
                 .type = STRING_COMPONENT_COMMAND_SUBSTITUTION,
                 .length = length,
-                .command_substitution = NULL};
+                .command_substitution = NULL,
+                .quoted = quoted};
             break;
         }
     }
@@ -77,13 +82,14 @@ void add_string_component_from_value(struct ShellString *str,
     add_string_component(str, component);
 }
 
-void add_command_substitution(struct ShellString *str,
-                              struct Program *program) {
+void add_command_substitution(struct ShellString *str, struct Program *program,
+                              bool quoted) {
     assert(program != NULL);
     add_string_component(str, (struct StringComponent){
                                   .type = STRING_COMPONENT_COMMAND_SUBSTITUTION,
                                   .length = 0,
-                                  .command_substitution = program});
+                                  .command_substitution = program,
+                                  .quoted = quoted});
 }
 
 void free_string_component(const struct StringComponent *component) {
@@ -131,9 +137,13 @@ void append(struct String *string, const char *value) {
 }
 
 void append_n(struct String *string, const char *value, int length) {
-    string->string = grow_string(string->string, string->length + length);
+    if (length <= 0)
+        return;
+
+    string->string = grow_string(string->string, string->length + length + 1);
     memcpy(&string->string[string->length], value, length);
     string->length += length;
+    string->string[string->length] = '\0';  // Null-terminate the string
 }
 
 void append_n_terminate(struct String *string, const char *value, int length) {
@@ -147,21 +157,14 @@ bool is_null_string(struct ShellString *str) {
             str->components[0].type != STRING_COMPONENT_COMMAND_SUBSTITUTION);
 }
 
-struct String strip(const struct String *string) {
+struct String strip_end(const struct String *string) {
     int length = string->length;
-    int start = 0;
-
-    while (start < string->length && isspace(string->string[start])) {
-        start++;
-        length--;
-    }
-
     int end = string->length - 1;
-    while (end >= start && isspace(string->string[end])) {
+    while (end >= 0 && isspace(string->string[end])) {
         end--;
         length--;
     }
 
-    return (struct String){.string = strndup(&string->string[start], length),
+    return (struct String){.string = strndup(string->string, length),
                            .length = length};
 }

--- a/src/util.c
+++ b/src/util.c
@@ -84,9 +84,9 @@ struct String number_to_string(int number) {
     return (struct String){.string = buf, .length = length};
 }
 
-char *read_all_stdin(void) {
-    size_t size = 0;
-    size_t capacity = 1024;
+struct String read_all_fd(int fd) {
+    int size = 0;
+    int capacity = 1024;
     char *buffer = malloc(capacity);
     if (!buffer) {
         CASH_ERROR(EXIT_FAILURE,
@@ -94,8 +94,14 @@ char *read_all_stdin(void) {
         exit(EXIT_FAILURE);
     }
 
-    size_t n;
-    while ((n = fread(buffer + size, 1, capacity - size - 1, stdin)) > 0) {
+    int n;
+    while ((n = read(fd, buffer + size, capacity - size - 1)) > 0) {
+        if (n == -1) {
+            CASH_PERROR(EXIT_FAILURE, "read",
+                        "error while reading from file descriptor %d", fd);
+            free(buffer);
+            exit(EXIT_FAILURE);
+        }
         size += n;
         if (size == capacity - 1) {
             capacity *= 2;
@@ -111,7 +117,7 @@ char *read_all_stdin(void) {
     }
 
     buffer[size] = '\0';
-    return buffer;
+    return (struct String){.string = buffer, .length = size};
 }
 
 char *read_file(const char *path) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -36,9 +36,9 @@ static int make_process_list(struct Vm *vm, struct Expr *expr,
                              struct Process ***process_list);
 static int make_job(struct Vm *vm, struct Expr *expr, struct Job *job);
 
-static struct RawRedirection get_redirection(const struct Vm *vm,
+static struct RawRedirection get_redirection(struct Vm *vm,
                                              const struct Redirection *redir);
-static int get_final_command(const struct Vm *vm, struct Command *command,
+static int get_final_command(struct Vm *vm, struct Command *command,
                              struct RawCommand *raw_command);
 
 static int exec_expression(struct Vm *vm, struct Expr *expr, struct Job **job);
@@ -47,10 +47,15 @@ static void backup_fds(int *saved_in, int *saved_out, int *saved_err);
 static void restore_fds(int saved_in, int saved_out, int saved_err);
 static int run_command(struct Vm *vm, struct Expr *expr, struct Job **job);
 
-static struct String expand_component(const struct Vm *vm,
+static struct String expand_component(struct Vm *vm,
                                       const struct StringComponent *component);
-static struct String to_string(const struct Vm *vm,
-                               const struct ShellString *string);
+static struct String expand_var_sub(const struct Vm *vm,
+                                    const struct StringComponent *component);
+static struct String expand_command_sub(
+    struct Vm *vm, const struct StringComponent *component);
+static struct String expand_string(const struct Vm *vm,
+                                   const struct StringComponent *component);
+static struct String to_string(struct Vm *vm, const struct ShellString *string);
 
 static void update_prompt(struct Vm *vm);
 
@@ -193,7 +198,7 @@ int run_program(struct Vm *vm, const struct Program *program) {
     return vm->previous_exit_code;
 }
 
-static int get_final_command(const struct Vm *vm, struct Command *command,
+static int get_final_command(struct Vm *vm, struct Command *command,
                              struct RawCommand *raw_command) {
     if (command->is_subshell) {
         *raw_command = (struct RawCommand){.is_subshell = true,
@@ -282,7 +287,7 @@ static int get_final_command(const struct Vm *vm, struct Command *command,
     return 0;
 }
 
-static struct RawRedirection get_redirection(const struct Vm *vm,
+static struct RawRedirection get_redirection(struct Vm *vm,
                                              const struct Redirection *redir) {
     struct RawRedirection raw_redir = {
         .left = redir->left,
@@ -540,6 +545,36 @@ static int make_process_list(struct Vm *vm, struct Expr *expr,
     }
 }
 
+static int make_subshell_job(struct Vm *vm, struct Program *program, int in,
+                             int out, int err, struct Job *jobp) {
+    struct Process *process = malloc(sizeof(struct Process));
+    CHECK_ALLOC(process);
+    *process = (struct Process){
+        .next_process = NULL,
+        .raw_command =
+            (struct RawCommand){
+                .is_subshell = true,
+                .as_subshell = *program,
+            },
+        .pid = 0,
+        .status = 0,
+        .completed = false,
+        .stopped = false,
+    };
+    *jobp = (struct Job){
+        .next_job = NULL,
+        .first_process = process,
+        .command = strndup(program->text, program->text_length),
+        .pgid = 0,
+        .notified = false,
+        .term_state = vm->shell_term_state,
+        .stdin = in,
+        .stdout = out,
+        .stderr = err,
+    };
+    return 0;
+}
+
 static int make_job(struct Vm *vm, struct Expr *expr, struct Job *jobp) {
     CASH_DEBUG(RED "expr: ");
     CASH_DEBUG_EXPR(print_expr(expr, 0));
@@ -562,95 +597,124 @@ static int make_job(struct Vm *vm, struct Expr *expr, struct Job *jobp) {
     return 0;
 }
 
-struct String expand_component(const struct Vm *vm,
+struct String expand_component(struct Vm *vm,
                                const struct StringComponent *component) {
-    char *string = NULL;
-
     switch (component->type) {
-        case STRING_COMPONENT_VAR_SUB: {
-            if (component->length == 1 &&
-                component->var_substitution[0] == '?') {
-                return number_to_string(vm->previous_exit_code);
-            }
-
-            if (component->length == 1 &&
-                component->var_substitution[0] == '#') {
-                return number_to_string(vm->argc);
-            }
-
-            int n;
-            if ((n = is_number(component->var_substitution)) != -1) {
-                if (n > vm->argc)
-                    return (struct String){NULL, 0};
-                return (struct String){.string = strdup(vm->argv[n]),
-                                       .length = (int)strlen(vm->argv[n])};
-            }
-
-            const char *value = getenv(component->var_substitution);
-            if (value == NULL) {
-                return (struct String){NULL, 0};
-            }
-            return (struct String){.string = strdup(value),
-                                   .length = (int)strlen(value)};
-        }
+        case STRING_COMPONENT_VAR_SUB:
+            return expand_var_sub(vm, component);
         case STRING_COMPONENT_LITERAL:
-        case STRING_COMPONENT_DQ: {
-            int i, start = 0, total_size = 0;
-
-            if (component->type == STRING_COMPONENT_LITERAL &&
-                component->literal[0] == '~') {
-                start =
-                    tilde_expansion(vm, component->literal, component->length,
-                                    &string, &total_size);
-            }
-
-            for (i = start; i < component->length; ++i) {
-                if (component->literal[i] == '\\') {
-                    if (i + 1 == component->length)
-                        break;
-                    if (component->type == STRING_COMPONENT_LITERAL ||
-                        component->literal[i + 1] == '\\' ||
-                        (component->type == STRING_COMPONENT_DQ &&
-                         kIsEscapableInDQ[(unsigned char)
-                                              component->literal[i + 1]])) {
-                    } else
-                        continue;
-
-                    const int length = i - start + 1;
-                    string = grow_string(string, total_size + length);
-                    strncpy(&string[total_size], &component->literal[start],
-                            length - 1);
-                    string[total_size + length - 1] = component->literal[i + 1];
-                    total_size += length;
-                    start = i + 2;
-                    i++;
-                }
-            }
-            if (start != i) {
-                const int length = i - start;
-                string = grow_string(string, total_size + length);
-                strncpy(&string[total_size], &component->literal[start],
-                        length);
-                total_size += length;
-            }
-
-            return (struct String){string, total_size};
-        }
-
+        case STRING_COMPONENT_DQ:
+            return expand_string(vm, component);
         case STRING_COMPONENT_SQ:
             return (struct String){
                 strndup(component->literal, component->length),
                 component->length};
+        case STRING_COMPONENT_COMMAND_SUBSTITUTION:
+            return expand_command_sub(vm, component);
 
         default:
             return (struct String){.string = "", .length = 0};
     }
 }
 
+static struct String expand_var_sub(const struct Vm *vm,
+                                    const struct StringComponent *component) {
+    if (component->length == 1 && component->var_substitution[0] == '?') {
+        return number_to_string(vm->previous_exit_code);
+    }
+
+    if (component->length == 1 && component->var_substitution[0] == '#') {
+        return number_to_string(vm->argc);
+    }
+
+    int n;
+    if ((n = is_number(component->var_substitution)) != -1) {
+        if (n > vm->argc)
+            return (struct String){NULL, 0};
+        return (struct String){.string = strdup(vm->argv[n]),
+                               .length = (int)strlen(vm->argv[n])};
+    }
+
+    const char *value = getenv(component->var_substitution);
+    if (value == NULL) {
+        return (struct String){NULL, 0};
+    }
+    return (struct String){.string = strdup(value),
+                           .length = (int)strlen(value)};
+}
+
+static struct String expand_string(const struct Vm *vm,
+                                   const struct StringComponent *component) {
+    int i, start = 0, total_size = 0;
+    char *string = NULL;
+
+    if (component->type == STRING_COMPONENT_LITERAL &&
+        component->literal[0] == '~') {
+        start = tilde_expansion(vm, component->literal, component->length,
+                                &string, &total_size);
+    }
+
+    for (i = start; i < component->length; ++i) {
+        if (component->literal[i] == '\\') {
+            if (i + 1 == component->length)
+                break;
+            if (component->type == STRING_COMPONENT_LITERAL ||
+                component->literal[i + 1] == '\\' ||
+                (component->type == STRING_COMPONENT_DQ &&
+                 kIsEscapableInDQ[(unsigned char)component->literal[i + 1]])) {
+            } else
+                continue;
+
+            const int length = i - start + 1;
+            string = grow_string(string, total_size + length);
+            strncpy(&string[total_size], &component->literal[start],
+                    length - 1);
+            string[total_size + length - 1] = component->literal[i + 1];
+            total_size += length;
+            start = i + 2;
+            i++;
+        }
+    }
+    if (start != i) {
+        const int length = i - start;
+        string = grow_string(string, total_size + length);
+        strncpy(&string[total_size], &component->literal[start], length);
+        total_size += length;
+    }
+
+    return (struct String){string, total_size};
+}
+
+static struct String expand_command_sub(
+    struct Vm *vm, const struct StringComponent *component) {
+    struct Job *job = malloc(sizeof(struct Job));
+    CHECK_ALLOC(job);
+
+    int pipefd[2];
+    if (pipe(pipefd) == -1) {
+        CASH_PERROR(EXIT_FAILURE, "pipe", "could not create pipe%s", "");
+        exit(EXIT_FAILURE);
+    }
+
+    make_subshell_job(vm, component->command_substitution, STDIN_FILENO,
+                      pipefd[1], STDERR_FILENO, job);
+    launch_job(vm, job, true);
+    vm->previous_exit_code = job->first_process->status % 0xFF;
+
+    close(pipefd[1]);
+
+    struct String output = read_all_fd(pipefd[0]);
+    close(pipefd[0]);
+
+    struct String stripped = strip(&output);
+    free_string(&output);
+    return stripped;
+}
+
 // TODO: can make expand_component write directly to a single
 // allocated string, instead of allocating a new one for each
 // compoenent and then freeing it
-struct String to_string(const struct Vm *vm, const struct ShellString *string) {
+struct String to_string(struct Vm *vm, const struct ShellString *string) {
     char *str = NULL;
     int total_size = 0;
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -47,16 +47,6 @@ static void backup_fds(int *saved_in, int *saved_out, int *saved_err);
 static void restore_fds(int saved_in, int saved_out, int saved_err);
 static int run_command(struct Vm *vm, struct Expr *expr, struct Job **job);
 
-static struct String expand_component(struct Vm *vm,
-                                      const struct StringComponent *component);
-static struct String expand_var_sub(const struct Vm *vm,
-                                    const struct StringComponent *component);
-static struct String expand_command_sub(
-    struct Vm *vm, const struct StringComponent *component);
-static struct String expand_string(const struct Vm *vm,
-                                   const struct StringComponent *component);
-static struct String to_string(struct Vm *vm, const struct ShellString *string);
-
 static void update_prompt(struct Vm *vm);
 
 static bool is_path(const char *cmd);
@@ -64,13 +54,37 @@ static bool is_executable(const char *path);
 
 static char *find_in_path(const char *cmd);
 
+struct UnsplitString {
+    struct String expansion;
+    bool is_expanded;
+    bool was_quoted;
+};
+
+static struct UnsplitString expand_component(
+    struct Vm *vm, const struct StringComponent *component);
+static struct UnsplitString expand_var_sub(
+    const struct Vm *vm, const struct StringComponent *component);
+static struct UnsplitString expand_command_sub(
+    struct Vm *vm, const struct StringComponent *component);
+static struct UnsplitString expand_string(
+    const struct Vm *vm, const struct StringComponent *component);
+static struct String to_string(struct Vm *vm, const struct ShellString *string);
+
 static int tilde_expansion(const struct Vm *vm, const char *source, int len,
                            char **dest, int *total_size);
+
+struct WordList {
+    char **words;
+    int word_count;
+    int word_capacity;
+};
+static struct String into_words(struct Vm *vm, const struct ShellString *string,
+                                struct WordList *word_list);
 
 static int change_dir(struct Vm *vm, const struct RawCommand *command);
 static int exit_shell(struct Vm *vm, const struct RawCommand *raw_command);
 
-static const bool kIsEscapableInDQ[] = {
+static const bool kIsEscapableInDQ[128] = {
     ['"'] = true,
     ['\\'] = true,
     ['$'] = true,
@@ -155,19 +169,10 @@ void free_vm(const struct Vm *vm) {
 }
 
 int run_program(struct Vm *vm, const struct Program *program) {
-    CASH_DEBUG(YELLOW "running program in vm %p (pid: %d)" RESET, (void *)vm,
-               getpid());
-    CASH_DEBUG_EXPR(print_program(program, 0));
-    CASH_DEBUG("\n");
-
     for (int i = 0; i < program->statement_count; ++i) {
         struct Job *job = NULL;
 
-        CASH_DEBUG("expr %d", i);
-        CASH_DEBUG_EXPR(print_expr(&program->statements[i].expr, 0));
-        CASH_DEBUG("\n");
-        int res = exec_expression(vm, &program->statements[i].expr, &job);
-        CASH_DEBUG("expr has been execed with %d\n", res);
+        exec_expression(vm, &program->statements[i].expr, &job);
 
         if (vm->is_subshell) {
             if (vm->job_list != job)
@@ -182,11 +187,6 @@ int run_program(struct Vm *vm, const struct Program *program) {
             // }
         }
 
-        if (i + 1 < program->statement_count) {
-            CASH_DEBUG("next one is %d (exit: %d)\n", i + 1, vm->exit);
-            CASH_DEBUG_EXPR(print_expr(&program->statements[i + 1].expr, 0));
-            CASH_DEBUG("\n");
-        }
         // run_command(vm, &program->statements[i].command);
     }
     if (vm->is_subshell)
@@ -206,13 +206,15 @@ static int get_final_command(struct Vm *vm, struct Command *command,
     } else {
         char *executable = NULL;
         char **args = NULL;
+        struct WordList word_list = {
+            .words = NULL, .word_count = 0, .word_capacity = 0};
 
         if (command->as_cmd.command_name.component_count != 0) {
-            const struct String command_name =
-                to_string(vm, &command->as_cmd.command_name);
-            CASH_DEBUG("Name: %s\n", command_name.string);
+            into_words(vm, &command->as_cmd.command_name, &word_list);
+            const char *command_name = word_list.words[0];
+            CASH_DEBUG("Name: %s\n", command_name);
 
-            if (strcmp(command_name.string, "ls") == 0) {
+            if (strcmp(command_name, "ls") == 0) {
                 struct ShellString new_arg = {.components = NULL,
                                               .component_count = 0,
                                               .component_capacity = 0};
@@ -221,55 +223,40 @@ static int get_final_command(struct Vm *vm, struct Command *command,
                 add_argument(&command->as_cmd.arguments, new_arg);
             }
 
-            args = malloc((command->as_cmd.arguments.argument_count + 2) *
-                          sizeof(*args));
-            if (!args) {
-                CASH_ERROR(EXIT_FAILURE,
-                           "could not allocate memory for arguments%s\n", "");
-                exit(EXIT_FAILURE);
-            }
-
-            args[0] = strndup(command_name.string, command_name.length);
-            CASH_DEBUG("arg 0: (len %d) %s\n", command_name.length, args[0]);
-
             for (int i = 0; i < command->as_cmd.arguments.argument_count; ++i) {
-                const struct String arg =
-                    to_string(vm, &command->as_cmd.arguments.arguments[i]);
-                CASH_DEBUG("arg %d: (len %d) %s\n", i + 1, arg.length,
-                           arg.string);
-
-                args[i + 1] = arg.string;
+                into_words(vm, &command->as_cmd.arguments.arguments[i],
+                           &word_list);
             }
-            args[command->as_cmd.arguments.argument_count + 1] = NULL;
-            CASH_DEBUG("-----------------\n");
+            ADD_LIST(&word_list, word_count, word_capacity, words, NULL,
+                     char *);
 
-            if (is_path(command_name.string)) {
-                if (!is_executable(command_name.string)) {
+            if (is_path(command_name)) {
+                if (!is_executable(command_name)) {
                     CASH_ERROR(EXIT_FAILURE,
                                "the path `%s` is not an executable\n",
-                               command_name.string);
-                    free_string(&command_name);
+                               command_name);
                     return EXIT_FAILURE;
                 }
-                executable = strndup(command_name.string, command_name.length);
+                executable = strdup(command_name);
             } else {
-                char *res = find_in_path(command_name.string);
+                char *res = find_in_path(command_name);
                 if (res == NULL) {
-                    executable =
-                        strndup(command_name.string, command_name.length);
+                    executable = strdup(command_name);
                 } else {
                     executable = res;
                 }
             }
-
-            free_string(&command_name);
         }
 
+        CASH_DEBUG("Name: %s\n", executable);
+        for (int i = 0; i < word_list.word_count; ++i) {
+            CASH_DEBUG("arg %d: %s\n", i, word_list.words[i]);
+        }
         *raw_command = (struct RawCommand){
             .is_subshell = false,
             .as_cmd = {
                 .name = executable,
-                .args = args,
+                .args = word_list.words,
                 .args_count = command->as_cmd.arguments.argument_count + 1}};
     }
 
@@ -385,10 +372,6 @@ static void restore_fds(int saved_in, int saved_out, int saved_err) {
 int run_command(struct Vm *vm, struct Expr *expr, struct Job **jobp) {
     if (!vm->repl_mode)
         remove_completed_jobs(vm);
-
-    CASH_DEBUG(BLUE "running command ");
-    CASH_DEBUG_EXPR(print_expr(expr, 0));
-    CASH_DEBUG("\n");
 
     struct Job *job = malloc(sizeof(struct Job));
     CHECK_ALLOC(job);
@@ -576,10 +559,6 @@ static int make_subshell_job(struct Vm *vm, struct Program *program, int in,
 }
 
 static int make_job(struct Vm *vm, struct Expr *expr, struct Job *jobp) {
-    CASH_DEBUG(RED "expr: ");
-    CASH_DEBUG_EXPR(print_expr(expr, 0));
-    CASH_DEBUG(RESET "\n has   expr_text: %.*s\n", expr->expr_text.length,
-               expr->expr_text.string);
     struct Job job = {
         .first_process = NULL,
         .next_job = NULL,
@@ -597,8 +576,8 @@ static int make_job(struct Vm *vm, struct Expr *expr, struct Job *jobp) {
     return 0;
 }
 
-struct String expand_component(struct Vm *vm,
-                               const struct StringComponent *component) {
+struct UnsplitString expand_component(struct Vm *vm,
+                                      const struct StringComponent *component) {
     switch (component->type) {
         case STRING_COMPONENT_VAR_SUB:
             return expand_var_sub(vm, component);
@@ -606,45 +585,56 @@ struct String expand_component(struct Vm *vm,
         case STRING_COMPONENT_DQ:
             return expand_string(vm, component);
         case STRING_COMPONENT_SQ:
-            return (struct String){
-                strndup(component->literal, component->length),
-                component->length};
+            return (struct UnsplitString){
+                .expansion = {strndup(component->literal, component->length),
+                              component->length},
+                false,
+                true};
         case STRING_COMPONENT_COMMAND_SUBSTITUTION:
             return expand_command_sub(vm, component);
 
         default:
-            return (struct String){.string = "", .length = 0};
+            return (struct UnsplitString){.expansion = {"", 0}, false, false};
     }
 }
 
-static struct String expand_var_sub(const struct Vm *vm,
-                                    const struct StringComponent *component) {
+static struct UnsplitString expand_var_sub(
+    const struct Vm *vm, const struct StringComponent *component) {
     if (component->length == 1 && component->var_substitution[0] == '?') {
-        return number_to_string(vm->previous_exit_code);
+        return (struct UnsplitString){
+            .expansion = number_to_string(vm->previous_exit_code),
+            .is_expanded = true,
+            .was_quoted = component->quoted};
     }
 
     if (component->length == 1 && component->var_substitution[0] == '#') {
-        return number_to_string(vm->argc);
+        return (struct UnsplitString){number_to_string(vm->argc), true,
+                                      component->quoted};
     }
 
     int n;
     if ((n = is_number(component->var_substitution)) != -1) {
         if (n > vm->argc)
-            return (struct String){NULL, 0};
-        return (struct String){.string = strdup(vm->argv[n]),
-                               .length = (int)strlen(vm->argv[n])};
+            return (struct UnsplitString){
+                .expansion = {NULL, 0}, true, component->quoted};
+        return (struct UnsplitString){
+            {.string = strdup(vm->argv[n]), .length = (int)strlen(vm->argv[n])},
+            true,
+            component->quoted};
     }
 
     const char *value = getenv(component->var_substitution);
     if (value == NULL) {
-        return (struct String){NULL, 0};
+        return (struct UnsplitString){{NULL, 0}, true, component->quoted};
     }
-    return (struct String){.string = strdup(value),
-                           .length = (int)strlen(value)};
+    return (struct UnsplitString){
+        {.string = strdup(value), .length = (int)strlen(value)},
+        true,
+        component->quoted};
 }
 
-static struct String expand_string(const struct Vm *vm,
-                                   const struct StringComponent *component) {
+static struct UnsplitString expand_string(
+    const struct Vm *vm, const struct StringComponent *component) {
     int i, start = 0, total_size = 0;
     char *string = NULL;
 
@@ -682,10 +672,14 @@ static struct String expand_string(const struct Vm *vm,
         total_size += length;
     }
 
-    return (struct String){string, total_size};
+    return (struct UnsplitString){
+        .expansion = {string, total_size},
+        .is_expanded = true,
+        .was_quoted = component->quoted,
+    };
 }
 
-static struct String expand_command_sub(
+static struct UnsplitString expand_command_sub(
     struct Vm *vm, const struct StringComponent *component) {
     struct Job *job = malloc(sizeof(struct Job));
     CHECK_ALLOC(job);
@@ -706,9 +700,75 @@ static struct String expand_command_sub(
     struct String output = read_all_fd(pipefd[0]);
     close(pipefd[0]);
 
-    struct String stripped = strip(&output);
+    struct String stripped = strip_end(&output);
+    CASH_DEBUG("output is %.*s\n", stripped.length, stripped.string);
     free_string(&output);
-    return stripped;
+    return (struct UnsplitString){
+        .expansion = stripped,
+        .is_expanded = true,
+        .was_quoted = component->quoted,
+    };
+}
+
+static const bool IS_IFS_SPACE[128] = {
+    [' '] = true,
+    ['\t'] = true,
+    ['\n'] = true,
+};
+
+struct StringView next_word(const struct String *str, int start,
+                            int *next_start) {
+    int i = start;
+    while (i < str->length && !IS_IFS_SPACE[(unsigned char)str->string[i]]) {
+        assert(str->string[i] != '\0');
+        i++;
+    }
+    int word_end = i;
+    if (i == str->length)
+        *next_start = -1;
+    else {
+        while (i < str->length && IS_IFS_SPACE[(unsigned char)str->string[i]]) {
+            i++;
+        }
+        *next_start = i;
+    }
+    return (struct StringView){&str->string[start], word_end - start};
+}
+
+static struct String into_words(struct Vm *vm, const struct ShellString *string,
+                                struct WordList *word_list) {
+    struct String str = {NULL, 0};
+    struct String total_str = {NULL, 0};
+
+    for (int i = 0; i < string->component_count; ++i) {
+        const struct StringComponent *component = &string->components[i];
+        const struct UnsplitString expanded = expand_component(vm, component);
+        int start = 0;
+
+        append_n(&total_str, expanded.expansion.string,
+                 expanded.expansion.length);
+        if (expanded.was_quoted) {
+            append_n(&str, expanded.expansion.string,
+                     expanded.expansion.length);
+        } else {
+            do {
+                struct StringView word =
+                    next_word(&expanded.expansion, start, &start);
+                append_n(&str, word.string, word.length);
+
+                if (str.length > 0) {
+                    ADD_LIST(word_list, word_count, word_capacity, words,
+                             str.string, char *);
+                    str = (struct String){NULL, 0};
+                }
+            } while (start != -1);
+        }
+    }
+
+    if (str.length > 0)
+        ADD_LIST(word_list, word_count, word_capacity, words, str.string,
+                 char *);
+    return total_str;
 }
 
 // TODO: can make expand_component write directly to a single
@@ -720,7 +780,7 @@ struct String to_string(struct Vm *vm, const struct ShellString *string) {
 
     for (int i = 0; i < string->component_count; ++i) {
         const struct String expanded =
-            expand_component(vm, &string->components[i]);
+            expand_component(vm, &string->components[i]).expansion;
         const int is_last_comp = i + 1 == string->component_count;
         const int new_alloc_size = total_size + expanded.length + is_last_comp;
 


### PR DESCRIPTION
This PR adds the ability to use command substitutions inside quoted and unquoted strings. It also adds the [word splitting stage](https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html) to the expansion stages of the shell.

### String Handling Enhancements
* Added a `quoted` field to `struct StringComponent` to track whether a string component is inside a double-quoted string (`include/cash/string.h`, [include/cash/string.hR27-R28](diffhunk://#diff-765b269984e98771482c421eead6d01c72687bb29e71aad6e9fbff71437fa618R27-R28)).
* Introduced new functions, such as `add_string_component_from_value` and `add_command_substitution`, to handle string components more flexibly, including quoted components and command substitutions (`include/cash/string.h`, [include/cash/string.hL49-R76](diffhunk://#diff-765b269984e98771482c421eead6d01c72687bb29e71aad6e9fbff71437fa618L49-R76)).
* Updated `print_string_component` to visually indicate quoted components during debugging (`src/ast.c`, [[1]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL91-R93) [[2]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL103-R122).

### Parser and Lexer Improvements
* Added support for command substitution parsing in the lexer, including a new `consume_command_substitution` function and integration with the parser (`src/parser/lexer.c`, [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R477-R485) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L490-R543).
* Introduced `subparser_from_lexer` and `make_subparser` functions to streamline the creation of subparsers for command substitutions (`src/parser/parser.c`, [[1]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL60-R73) [[2]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL99-R111).
* Removed unused fields and methods, such as `next_token` in `struct Parser`, to simplify the parser structure (`include/cash/parser/parser.h`, [include/cash/parser/parser.hL11-R22](diffhunk://#diff-75122cc19b6c3816e883c093b34f3b9bfd0445a08e4db5e87103f6b32a23daa6L11-R22)).

### Debugging Utilities
* Expanded the `debug_files` array to include additional files (`lexer.c`, `vm.c`) for selective debugging (`include/cash/util.h`, [include/cash/util.hL9-R16](diffhunk://#diff-523dc377fe2a69990fa8a7d9f02738c5e2132027cbd50818906f7fe6ed746f10L9-R16)).
* Refactored debug macros to use unique variable names for loop indices, reducing potential conflicts (`include/cash/util.h`, [include/cash/util.hL25-R27](diffhunk://#diff-523dc377fe2a69990fa8a7d9f02738c5e2132027cbd50818906f7fe6ed746f10L25-R27)).

### Code Cleanup and Maintenance
* Removed unused functions, such as `lexer_pop_token`, and redundant code in the lexer (`src/parser/lexer.c`, [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R39-R44) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L94-L99).
* Replaced the `read_all_stdin` function with `read_all_fd` for more general-purpose file descriptor handling (`src/main.c`, [src/main.cL20-R20](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L20-R20)).
