### PR TITLE
Command substitution

### DIFF
--- a/src/job_control.c
+++ b/src/job_control.c
@@ -480,8 +480,7 @@ int fg(struct Vm *vm, const struct RawCommand *raw_command) {
     }
 
     if (vm->repl_mode)
-        printf(RED "weeeeeewoooooooooweeeeeeeeeeeewooooooo %s\n" RESET,
-               job->command);
+        printf("%s\n", job->command);
     continue_job(vm, job, true);
     return 0;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -205,7 +205,6 @@ static int get_final_command(struct Vm *vm, struct Command *command,
                                            .as_subshell = command->as_subshell};
     } else {
         char *executable = NULL;
-        char **args = NULL;
         struct WordList word_list = {
             .words = NULL, .word_count = 0, .word_capacity = 0};
 


### PR DESCRIPTION
### Code cleanup:
* [`src/vm.c`](diffhunk://#diff-b7d97be9c98fd50d49b9f2d6ee9bd3e4da589e223eeb0a06824d7af57d23efe6L208): Removed the unused `args` variable in the `get_final_command` function.

### Output formatting:
* [`src/job_control.c`](diffhunk://#diff-d1902cc224198eeb806485a883e70a1adcdaff36bfbb112bdcd4e22646900ec6L483-R483): Simplified the `printf` statement in the `fg` function to remove unnecessary and verbose debugging output.